### PR TITLE
Scoped block

### DIFF
--- a/components/ScopedBlock/ScopedBlock.tsx
+++ b/components/ScopedBlock/ScopedBlock.tsx
@@ -1,0 +1,21 @@
+import { useRouter } from "next/router";
+import { ScopesType, getScopeFromUrl } from "layouts/DocsPage/context";
+
+interface ScopedBlockProps {
+  scope: ScopesType;
+  children: React.ReactNode;
+}
+
+export const ScopedBlock = ({ scope, children }: ScopedBlockProps) => {
+  const router = useRouter();
+  const urlScope = getScopeFromUrl(router.asPath);
+  let isDisplayedBlock: boolean;
+
+  if (Array.isArray(scope)) {
+    isDisplayedBlock = scope.some((propsScope) => propsScope === urlScope);
+  } else {
+    isDisplayedBlock = scope === urlScope;
+  }
+
+  return isDisplayedBlock ? <>{children}</> : null;
+};

--- a/components/ScopedBlock/index.ts
+++ b/components/ScopedBlock/index.ts
@@ -1,0 +1,1 @@
+export { ScopedBlock as default } from "./ScopedBlock";

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -118,9 +118,9 @@ export const getCurrentCategoryIndex = (
   categories: NavigationCategory[],
   href: string
 ) => {
-  const scopeLessHref = href.split("?")[0];
+  const scopelessHref = href.split("?")[0];
   const index = categories.findIndex(({ entries }) =>
-    hasSlug(entries, scopeLessHref)
+    hasSlug(entries, scopelessHref)
   );
 
   return index !== -1 ? index : null;

--- a/layouts/DocsPage/Scopes.tsx
+++ b/layouts/DocsPage/Scopes.tsx
@@ -56,7 +56,7 @@ const renderScope = (scope: Option) => (
 );
 
 const pickId = ({ value }: Option) => value;
-const pickOption = (optins: Option[], id: string) =>
+const pickOption = (options: Option[], id: string) =>
   options.find(({ value }) => value === id);
 
 export const Scopes = ({ ...props }: BoxProps) => {

--- a/layouts/DocsPage/components.tsx
+++ b/layouts/DocsPage/components.tsx
@@ -2,6 +2,7 @@ import Admonition from "components/Admonition";
 import Command, { CommandLine, CommandComment } from "components/Command";
 import BaseLink from "components/Link";
 import Notice from "components/Notice";
+import ScopedBlock from "components/ScopedBlock";
 import Snippet from "components/Snippet";
 import { Tabs, TabItem } from "components/Tabs";
 import {
@@ -65,6 +66,7 @@ export const components = {
   Command,
   CommandLine,
   CommandComment,
+  ScopedBlock,
   Tabs,
   TabItem,
   Tile,


### PR DESCRIPTION
Added a new component to be able to display context only for one or more scopes.

For example, if we write
```
<ScopedBlock scope="enterprise">
  As of version v3.0.1 we have `tsh` client binary available for Windows 64-bit
  architecture - `teleport` and `tctl` are not supported. Most `tsh` features are
  supported under Windows 10 1607+ as of Teleport v7.2. We support running
  `tsh ssh` under `cmd.exe`, PowerShell, and the Windows Terminal app.
</ScopedBlock>
```
Then the text that exists in the component `ScopedBlock` will be displayed only when "enterprise" is selected as the scope. 

Several scopes can also be passed to the ScopedBlock component props: `scope={["oss", "enterprise"]}`. In this case, the text will be displayed on the page when the "oss" or "enterprise" skope is selected.

Sample video

https://user-images.githubusercontent.com/41822696/158010417-4fb74f96-72b6-4c40-bfea-9b58f067b9e9.mov
