### PR TITLE
Fix semrush errors

### DIFF
--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -10,7 +10,6 @@ const formatTitle = (suffix: string, title?: string) => {
 };
 export interface HeadProps {
   title: string;
-  image?: string;
   description?: string;
   titleSuffix?: string;
   url?: string;
@@ -18,7 +17,6 @@ export interface HeadProps {
 }
 
 const Head = ({
-  image,
   description: propsDescription,
   title: propsTitle,
   titleSuffix,
@@ -26,16 +24,17 @@ const Head = ({
   noIndex,
 }: HeadProps) => {
   const router = useRouter();
-  const url = buildCanonicalUrl(propsUrl || router.asPath);
+  const url = buildCanonicalUrl(router.basePath, propsUrl || router.asPath);
   const title = formatTitle(titleSuffix, propsTitle);
   const description = propsDescription || "";
+
   return (
     <NextHead>
       <title>{title}</title>
-      <link rel="icon" href="/static/favicon.ico" />
-      <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
-      <link rel="apple-touch-icon" href="/static/apple.png" />
-      <link rel="manifest" href="/static/manifest.webmanifest" />
+      <link rel="icon" href="/docs/favicon.ico" />
+      <link rel="icon" href="/docs/favicon.svg" type="image/svg+xml" />
+      <link rel="apple-touch-icon" href="/docs/apple.png" />
+      <link rel="manifest" href="/docs/manifest.webmanifest" />
       <link rel="canonical" href={url} />
       <meta name="description" content={description} />
       <meta name="author" content="Teleport" />
@@ -44,13 +43,12 @@ const Head = ({
       <meta property="og:url" content={url} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={`${host}/static/${image}`} />
+      <meta property="og:image" content={`${host}/docs/og-image.png`} />
     </NextHead>
   );
 };
 
 Head.defaultProps = {
-  image: "og-image.png",
   titleSuffix: "Teleport",
   description:
     "Teleport is available for free as an open source download. We also offer commercial subscription plans priced on the number of computing resources accessible via Teleport.",

--- a/components/Link/hooks.ts
+++ b/components/Link/hooks.ts
@@ -25,15 +25,24 @@ export const useCurrentHref = () => {
  */
 
 export const useNormalizedHref = (href: string) => {
-  const { asPath } = useRouter();
+  const { asPath, basePath } = useRouter();
+
+  const noBaseHref = href.startsWith(basePath)
+    ? href.substring(basePath.length)
+    : href;
+
   const { scope } = useContext(DocsContext);
 
-  if (isHash(href) || isExternalLink(href) || isLocalAssetFile(href)) {
-    return href;
+  if (
+    isHash(noBaseHref) ||
+    isExternalLink(noBaseHref) ||
+    isLocalAssetFile(noBaseHref)
+  ) {
+    return noBaseHref;
   }
 
   const currentHref = normalizePath(asPath);
-  let fullHref = resolve(splitPath(currentHref).path, href);
+  let fullHref = resolve(splitPath(currentHref).path, noBaseHref);
 
   return updateScopeInUrl(fullHref, scope);
 };

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -72,8 +72,8 @@ export const normalizePath = (fullPath: string) => {
 
 // urls in meta and link tags in the headers should be absolute
 
-export const buildCanonicalUrl = (path: string) =>
-  `${host}${normalizePath(splitPath(path).path)}`;
+export const buildCanonicalUrl = (basePath: string, path: string) =>
+  `${host}${basePath}${normalizePath(splitPath(path).path)}`;
 
 export const getExtension = (href: string): string | undefined => {
   const parts = href.split("/");


### PR DESCRIPTION
Fixes:

- Fixed path to assets in head.
- Fixed canonical url.
- Fixed urls for static images.