### PR TITLE
Hide navigation items

### DIFF
--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -5,7 +5,8 @@ import Flex from "components/Flex";
 import HeadlessButton from "components/HeadlessButton";
 import Icon from "components/Icon";
 import { transition } from "components/system";
-import { DocsContext, ScopesType, getScopes } from "layouts/DocsPage/context";
+import { DocsContext, getScopes } from "layouts/DocsPage/context";
+import { ScopesType } from "layouts/DocsPage/types";
 
 export interface DetailsProps {
   scope?: ScopesType;

--- a/components/Notice/Notice.tsx
+++ b/components/Notice/Notice.tsx
@@ -4,7 +4,8 @@ import Box from "components/Box";
 import Flex, { FlexProps } from "components/Flex";
 import Icon from "components/Icon";
 import { variant, css } from "components/system";
-import { DocsContext, ScopesType, getScopes } from "layouts/DocsPage/context";
+import { DocsContext, getScopes } from "layouts/DocsPage/context";
+import { ScopesType } from "layouts/DocsPage/types";
 
 const types = ["warning", "tip", "note", "danger"] as const;
 

--- a/components/ScopedBlock/ScopedBlock.tsx
+++ b/components/ScopedBlock/ScopedBlock.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
-import { ScopesType, getScopeFromUrl } from "layouts/DocsPage/context";
+import { getScopeFromUrl } from "layouts/DocsPage/context";
+import { ScopesType } from "layouts/DocsPage/types";
 
 interface ScopedBlockProps {
   scope: ScopesType;

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -13,7 +13,8 @@ import Box from "components/Box";
 import Flex from "components/Flex";
 import HeadlessButton from "components/HeadlessButton";
 import { VersionWarning } from "layouts/DocsPage";
-import { ScopesType, DocsContext, getScopes } from "layouts/DocsPage/context";
+import { DocsContext, getScopes } from "layouts/DocsPage/context";
+import { ScopesType } from "layouts/DocsPage/types";
 
 const getSelectedLabel = (
   tabs: React.ReactComponentElement<typeof TabItem>[]

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -13,6 +13,8 @@ import Link, { useCurrentHref } from "components/Link";
 import { getScopeFromUrl } from "./context";
 import { NavigationItem, NavigationCategory } from "./types";
 
+const SCOPLESS_HREF_REGEX = /\?|\#/;
+
 interface DocsNavigationItemsProps {
   entries: NavigationItem[];
   onClick: () => void;
@@ -23,7 +25,7 @@ const DocsNavigationItems = ({
   onClick,
 }: DocsNavigationItemsProps) => {
   const router = useRouter();
-  const docPath = useCurrentHref();
+  const docPath = useCurrentHref().split(SCOPLESS_HREF_REGEX)[0];
   const urlScope = getScopeFromUrl(router.asPath);
 
   return (
@@ -34,21 +36,24 @@ const DocsNavigationItems = ({
           const childrenActive = entry.entries?.some(
             (entry) => entry.slug === docPath
           );
+          const hide = entry.hideInScopes === urlScope;
 
-          return entry.hideInScopes === urlScope ? null : (
-            <Box as="li" key={entry.slug}>
-              <NavigationLink
-                href={entry.slug}
-                active={entryActive || childrenActive}
-                isSelected={entryActive}
-                onClick={onClick}
-              >
-                {entry.title}
-                {!!entry.entries?.length && (
-                  <EllipsisIcon size="sm" name="ellipsis" />
-                )}
-              </NavigationLink>
-              {!!entry.entries?.length && (
+          return (
+            <Box as="li" key={entry.slug} display={hide ? "none" : "block"}>
+              {hide ? null : (
+                <NavigationLink
+                  href={entry.slug}
+                  active={entryActive || childrenActive}
+                  isSelected={entryActive}
+                  onClick={onClick}
+                >
+                  {entry.title}
+                  {!!entry.entries?.length && (
+                    <EllipsisIcon size="sm" name="ellipsis" />
+                  )}
+                </NavigationLink>
+              )}
+              {!!entry.entries?.length && !hide && (
                 <WrapperLevelMenu as="ul" listStyle="none">
                   <DocsNavigationItems
                     entries={entry.entries}
@@ -122,7 +127,7 @@ export const getCurrentCategoryIndex = (
   categories: NavigationCategory[],
   href: string
 ) => {
-  const scopelessHref = href.split(/\?|\#/)[0];
+  const scopelessHref = href.split(SCOPLESS_HREF_REGEX)[0];
   const index = categories.findIndex(({ entries }) =>
     hasSlug(entries, scopelessHref)
   );

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -36,11 +36,13 @@ const DocsNavigationItems = ({
           const childrenActive = entry.entries?.some(
             (entry) => entry.slug === docPath
           );
-          const hide = entry.hideInScopes === urlScope;
+          const isHide = Array.isArray(entry.hideInScopes)
+            ? entry.hideInScopes.includes(urlScope)
+            : entry.hideInScopes === urlScope;
 
           return (
-            <Box as="li" key={entry.slug} display={hide ? "none" : "block"}>
-              {hide ? null : (
+            <Box as="li" key={entry.slug}>
+              {isHide ? null : (
                 <NavigationLink
                   href={entry.slug}
                   active={entryActive || childrenActive}
@@ -53,7 +55,7 @@ const DocsNavigationItems = ({
                   )}
                 </NavigationLink>
               )}
-              {!!entry.entries?.length && !hide && (
+              {!!entry.entries?.length && !isHide && (
                 <WrapperLevelMenu as="ul" listStyle="none">
                   <DocsNavigationItems
                     entries={entry.entries}

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -13,7 +13,7 @@ import Link, { useCurrentHref } from "components/Link";
 import { getScopeFromUrl } from "./context";
 import { NavigationItem, NavigationCategory } from "./types";
 
-const SCOPLESS_HREF_REGEX = /\?|\#/;
+const SCOPELESS_HREF_REGEX = /\?|\#/;
 
 interface DocsNavigationItemsProps {
   entries: NavigationItem[];
@@ -25,7 +25,7 @@ const DocsNavigationItems = ({
   onClick,
 }: DocsNavigationItemsProps) => {
   const router = useRouter();
-  const docPath = useCurrentHref().split(SCOPLESS_HREF_REGEX)[0];
+  const docPath = useCurrentHref().split(SCOPELESS_HREF_REGEX)[0];
   const urlScope = getScopeFromUrl(router.asPath);
 
   return (
@@ -36,13 +36,13 @@ const DocsNavigationItems = ({
           const childrenActive = entry.entries?.some(
             (entry) => entry.slug === docPath
           );
-          const isHide = Array.isArray(entry.hideInScopes)
+          const isHidden = Array.isArray(entry.hideInScopes)
             ? entry.hideInScopes.includes(urlScope)
             : entry.hideInScopes === urlScope;
 
           return (
             <Box as="li" key={entry.slug}>
-              {isHide ? null : (
+              {isHidden ? null : (
                 <NavigationLink
                   href={entry.slug}
                   active={entryActive || childrenActive}
@@ -55,7 +55,7 @@ const DocsNavigationItems = ({
                   )}
                 </NavigationLink>
               )}
-              {!!entry.entries?.length && !isHide && (
+              {!!entry.entries?.length && !isHidden && (
                 <WrapperLevelMenu as="ul" listStyle="none">
                   <DocsNavigationItems
                     entries={entry.entries}
@@ -129,7 +129,7 @@ export const getCurrentCategoryIndex = (
   categories: NavigationCategory[],
   href: string
 ) => {
-  const scopelessHref = href.split(SCOPLESS_HREF_REGEX)[0];
+  const scopelessHref = href.split(SCOPELESS_HREF_REGEX)[0];
   const index = categories.findIndex(({ entries }) =>
     hasSlug(entries, scopelessHref)
   );

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import css from "@styled-system/css";
+import { useRouter } from "next/router";
 import { transition } from "components/system";
 import { all } from "components/system";
 import Box from "components/Box";
@@ -9,6 +10,7 @@ import HeadlessButton from "components/HeadlessButton";
 import Search from "components/Search";
 import Icon from "components/Icon";
 import Link, { useCurrentHref } from "components/Link";
+import { getScopeFromUrl } from "./context";
 import { NavigationItem, NavigationCategory } from "./types";
 
 interface DocsNavigationItemsProps {
@@ -20,7 +22,9 @@ const DocsNavigationItems = ({
   entries,
   onClick,
 }: DocsNavigationItemsProps) => {
+  const router = useRouter();
   const docPath = useCurrentHref();
+  const urlScope = getScopeFromUrl(router.asPath);
 
   return (
     <>
@@ -31,7 +35,7 @@ const DocsNavigationItems = ({
             (entry) => entry.slug === docPath
           );
 
-          return (
+          return entry.hideInScopes === urlScope ? null : (
             <Box as="li" key={entry.slug}>
               <NavigationLink
                 href={entry.slug}

--- a/layouts/DocsPage/Scopes.tsx
+++ b/layouts/DocsPage/Scopes.tsx
@@ -3,7 +3,8 @@ import Box, { BoxProps } from "components/Box";
 import Flex from "components/Flex";
 import Icon, { IconName } from "components/Icon";
 import { Dropdown } from "components/Dropdown";
-import { DocsContext, ScopeType } from "./context";
+import { DocsContext } from "./context";
+import { ScopeType } from "./types";
 
 interface Option {
   value: ScopeType;

--- a/layouts/DocsPage/context.tsx
+++ b/layouts/DocsPage/context.tsx
@@ -1,12 +1,7 @@
 import { useRouter } from "next/router";
 import { createContext, useState, useEffect } from "react";
 import { splitPath, buildPath } from "utils/url";
-import { VersionsInfo } from "./types";
-
-const scopeValues = ["oss", "cloud", "enterprise"] as const;
-
-export type ScopeType = typeof scopeValues[number];
-export type ScopesType = ScopeType | ScopeType[];
+import { VersionsInfo, scopeValues, ScopeType } from "./types";
 
 export const getScopes = (scope?: ScopeType | ScopeType[]) => {
   if (!scope) {

--- a/layouts/DocsPage/types.ts
+++ b/layouts/DocsPage/types.ts
@@ -3,9 +3,15 @@
 import type { IconName } from "components/Icon/types";
 import { VideoBarProps } from "components/VideoBar/types";
 
+export const scopeValues = ["oss", "cloud", "enterprise"] as const;
+
+export type ScopeType = typeof scopeValues[number];
+export type ScopesType = ScopeType | ScopeType[];
+
 export interface NavigationItem {
   title: string;
   slug: string;
+  hideInScopes?: ScopesType;
   entries?: NavigationItem[];
 }
 

--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -69,7 +69,12 @@ const validator = ajv.compile({
               properties: {
                 title: { type: "string" },
                 slug: { type: "string" },
-                hideInScopes: { type: ["string", "array"] },
+                hideInScopes: {
+                  type: ["string", "array"],
+                  items: {
+                    type: "string",
+                  },
+                },
                 entries: {
                   type: "array",
                   items: { $ref: "navigation-item" },

--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -69,7 +69,7 @@ const validator = ajv.compile({
               properties: {
                 title: { type: "string" },
                 slug: { type: "string" },
-                hideInScopes: { type: "string" || "array" },
+                hideInScopes: { type: ["string", "array"] },
                 entries: {
                   type: "array",
                   items: { $ref: "navigation-item" },

--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -69,6 +69,7 @@ const validator = ajv.compile({
               properties: {
                 title: { type: "string" },
                 slug: { type: "string" },
+                hideInScopes: { type: "string" || "array" },
                 entries: {
                   type: "array",
                   items: { $ref: "navigation-item" },


### PR DESCRIPTION
Fix #13 

Added hiding items in the side navigation

In order to add hiding items in the side navigation for a particular scope/scoop. In the [config.json](https://github.com/gravitational/teleport/blob/bea5f7fde4aee292f3873461432d6f041b82a2f9/docs/config.json) file, you need to add in an object of the form field `hideInScopes`.
```
{
    "title": "deployments",
    "slug": "/setup/deployments/",
    "hideInScopes": "cloud",
    "entries": [
        { "title": "AWS Terraform", "slug": "/setup/deployments/aws-terraform/" },
        { "title": "GCP", "slug": "/setup/deployments/gcp/" },
        { "title": "IBM", "slug": "/setup/deployments/ibm/" }
    ]
  },
```
This field can also be added to the level below:
```
{ "title": "AWS Terraform", "slug": "/setup/deployments/aws-terraform/", "hideInScopes": "cloud" },
```

A string can be passed to this field as an argument, if you want to hide this menu item in only one scopes. 
```"hideInScopes": "cloud",```

Or an array of strings can be passed.
```"hideInScopes": ["oss", "cloud"],```