### PR TITLE
Fix code highlight

### DIFF
--- a/components/Code/Code.module.css
+++ b/components/Code/Code.module.css
@@ -28,63 +28,63 @@
   }
 
   & :global {
-    .hljs-tag,
-    .hljs-keyword,
-    .hljs-selector-tag,
-    .hljs-literal,
-    .hljs-strong,
-    .hljs-name {
+    & .hljs-tag,
+    & .hljs-keyword,
+    & .hljs-selector-tag,
+    & .hljs-literal,
+    & .hljs-strong,
+    & .hljs-name {
       color: #f92672;
     }
 
-    .hljs-code {
+    & .hljs-code {
       color: #66d9ef;
     }
 
-    .hljs-class .hljs-title {
+    & .hljs-class .hljs-title {
       color: white;
     }
 
-    .hljs-attribute,
-    .hljs-symbol,
-    .hljs-regexp,
-    .hljs-link {
+    & .hljs-attribute,
+    & .hljs-symbol,
+    & .hljs-regexp,
+    & .hljs-link {
       color: #bf79db;
     }
 
-    .hljs-string,
-    .hljs-bullet,
-    .hljs-subst,
-    .hljs-title,
-    .hljs-section,
-    .hljs-emphasis,
-    .hljs-type,
-    .hljs-built_in,
-    .hljs-builtin-name,
-    .hljs-selector-attr,
-    .hljs-selector-pseudo,
-    .hljs-addition,
-    .hljs-variable,
-    .hljs-template-tag,
-    .hljs-template-variable {
+    & .hljs-string,
+    & .hljs-bullet,
+    & .hljs-subst,
+    & .hljs-title,
+    & .hljs-section,
+    & .hljs-emphasis,
+    & .hljs-type,
+    & .hljs-built_in,
+    & .hljs-builtin-name,
+    & .hljs-selector-attr,
+    & .hljs-selector-pseudo,
+    & .hljs-addition,
+    & .hljs-variable,
+    & .hljs-template-tag,
+    & .hljs-template-variable {
       color: #a6e22e;
     }
 
-    .hljs-comment,
-    .hljs-quote,
-    .hljs-deletion,
-    .hljs-meta {
+    & .hljs-comment,
+    & .hljs-quote,
+    & .hljs-deletion,
+    & .hljs-meta {
       color: #75715e;
     }
 
-    .hljs-keyword,
-    .hljs-selector-tag,
-    .hljs-literal,
-    .hljs-doctag,
-    .hljs-title,
-    .hljs-section,
-    .hljs-type,
-    .hljs-selector-id {
+    & .hljs-keyword,
+    & .hljs-selector-tag,
+    & .hljs-literal,
+    & .hljs-doctag,
+    & .hljs-title,
+    & .hljs-section,
+    & .hljs-type,
+    & .hljs-selector-id {
       font-weight: bold;
     }
   }


### PR DESCRIPTION
Nested styles without `&` does not work with `postcss-nested`, added `&` to make selectors work for code highlight.