### PR TITLE
Rewrite MDX links with query strings

### DIFF
--- a/server/remark-links.test.ts
+++ b/server/remark-links.test.ts
@@ -95,4 +95,22 @@ Suite("Work with mdx components", () => {
   assert.equal(result, '<Component href="../workflow/"/>\n');
 });
 
+Suite("Leaves query parameters untouched", () => {
+  // No trailing slash
+  const result1 = transformer({
+    value: "[Some link](../workflow.md?scope=cloud)",
+    path: "/docs/enterprize.md",
+  });
+
+  assert.equal(result1, "[Some link](../../workflow/?scope=cloud)\n");
+
+  // Trailing slash
+  const result2 = transformer({
+    value: "[Some link](../workflow.md/?scope=cloud)",
+    path: "/docs/enterprize.md",
+  });
+
+  assert.equal(result2, "[Some link](../../workflow/?scope=cloud)\n");
+});
+
 Suite.run();

--- a/server/remark-links.ts
+++ b/server/remark-links.ts
@@ -35,7 +35,7 @@ const updateHref = (basename: string, href: Href) => {
   }
   const isIndex = basename.match(/^index.mdx?$/);
   const prefix = isIndex ? "./" : "../";
-  const newHref = href.replace(/(\/)?(index)?\.mdx?/, "/");
+  const newHref = href.replace(/(\/)?(index)?\.mdx?\/?/, "/");
   const startsWithDot = /^\./.test(newHref);
   const startsWithSlash = /^\//.test(newHref);
 

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -90,7 +90,8 @@ export const isExternalLink = (href: string): boolean =>
 
 export const isHash = (href: string): boolean => href.startsWith("#");
 
-export const isMdxLink = (href: string): boolean => /\.md(x)?(#|$)/.test(href);
+export const isMdxLink = (href: string): boolean =>
+  /\.md(x)?(#|$|\/?\?)/.test(href);
 
 export const isPage = (href: string): boolean =>
   isMdxLink(href) || !getExtension(href);


### PR DESCRIPTION
Previously, given a link like [this](../mypage.mdx?scope=cloud),
remark-links would fail to rewrite the link href. This was because
the regexp used to check MDX links would only check for a # character
or the end of the line after the .mdx? file extension. This edits the
regexp to change the behavior and eventually enable us to link to other
scopes.