### PR TITLE
Add ScopeSwitchTile

### DIFF
--- a/components/ScopeSwitchTile/ScopeSwitchTile.tsx
+++ b/components/ScopeSwitchTile/ScopeSwitchTile.tsx
@@ -1,0 +1,42 @@
+import { DocsContext } from "layouts/DocsPage/context";
+import { ScopeType } from "layouts/DocsPage/types";
+import { useContext } from "react";
+import wrapperstyles from "components/Tile/TileSet.module.css";
+import Link from "components/Link";
+import Icon, { IconName } from "components/Icon";
+import tilestyles from "components/Tile/Tile.module.css";
+
+export interface ScopeSwitchTileProps {
+  children;
+  icon: IconName;
+  title: string;
+  scope: ScopeType;
+}
+
+const ScopeSwitchTile = ({
+  scope,
+  children,
+  icon,
+  title,
+}: ScopeSwitchTileProps) => {
+  const { setScope } = useContext(DocsContext);
+  return (
+    <div
+      className={wrapperstyles.tile}
+      onClick={(e) => {
+        e.preventDefault();
+        setScope(scope);
+      }}
+    >
+      <Link className={tilestyles.wrapper} href="#">
+        <h3 className={tilestyles.header}>
+          <Icon name={icon} size="lg" className={tilestyles.icon} />
+          <div className={tilestyles.title}>{title}</div>
+        </h3>
+        <div className={tilestyles.body}>{children}</div>
+      </Link>
+    </div>
+  );
+};
+
+export default ScopeSwitchTile;

--- a/components/ScopeSwitchTile/index.ts
+++ b/components/ScopeSwitchTile/index.ts
@@ -1,0 +1,1 @@
+export { default as ScopeSwitchTile } from "./ScopeSwitchTile";

--- a/layouts/DocsPage/components.tsx
+++ b/layouts/DocsPage/components.tsx
@@ -12,6 +12,7 @@ import {
   TileImage,
 } from "components/Tile";
 import Details from "components/Details";
+import { ScopeSwitchTile } from "components/ScopeSwitchTile";
 import {
   Code,
   H1,
@@ -74,4 +75,5 @@ export const components = {
   Notice,
   Snippet,
   Details,
+  ScopeSwitchTile,
 };


### PR DESCRIPTION
While working on adjusting the visibility of docs nav bar entries based
on scope (https://github.com/gravitational/teleport/issues/11383), I
realized that some nav bar sections are filled with irrelevant pages,
but a user might want to read the introduction of that section.

For example, the Enterprise section is irrelevant to OSS users, but
these users may still be interested in learning more about Teleport
Enterprise.

One possibility would be to leave these section as-is for readers with
an unintend scope. However, these readers would see edition warnings in
the pages within a section unless they changed the value of the scope
picker.

As an alternative, we can hide scope-irrelevant content from the nav
bar menu and section introduction pages, but include those pages, and
add a prominent link that enables the reader to change scope.

I've suggested the ScopeSwitchTile as a way of doing this. When a user
clicks the ScopeSwitchTile, the current scope changes to a caller-
configured value.

We would use a ScopedBlock to hide menu items in section introduction
pages from users with scopes that are not related to the section. We
would then use a ScopeSwitchTile to enable the user to switch scopes
and see the related content.