### PR TITLE
added a scope condition for the Admonition component

### DIFF
--- a/components/Admonition/Admonition.module.css
+++ b/components/Admonition/Admonition.module.css
@@ -26,6 +26,10 @@
   &.danger {
     --main-color: var(--color-danger);
   }
+
+  &.hidden {
+    display: none;
+  }
 }
 
 .header {

--- a/components/Admonition/Admonition.tsx
+++ b/components/Admonition/Admonition.tsx
@@ -1,4 +1,7 @@
 import cn from "classnames";
+import { useContext, useMemo } from "react";
+import { DocsContext, getScopes } from "layouts/DocsPage/context";
+import { ScopesType } from "layouts/DocsPage/types";
 import styles from "./Admonition.module.css";
 
 const capitalize = (text: string): string =>
@@ -10,13 +13,31 @@ export interface AdmonitionProps {
   type: typeof types[number];
   title: string;
   children: React.ReactNode;
+  scopeOnly: boolean;
+  scope?: ScopesType;
 }
 
-const Admonition = ({ type = "tip", title, children }: AdmonitionProps) => {
+const Admonition = ({
+  type = "tip",
+  title,
+  children,
+  scopeOnly = false,
+  scope,
+}: AdmonitionProps) => {
   const resolvedType = type && types.includes(type) ? type : "tip";
+  const { scope: currentScope } = useContext(DocsContext);
+  const scopes = useMemo(() => getScopes(scope), [scope]);
+  const isInCurrentScope = scopes.includes(currentScope);
+  const isHidden = scopeOnly && !isInCurrentScope;
 
   return (
-    <div className={cn(styles.wrapper, styles[resolvedType])}>
+    <div
+      className={cn(
+        styles.wrapper,
+        isHidden && styles.hidden,
+        styles[resolvedType]
+      )}
+    >
       <div className={styles.header}>{title || capitalize(type)}</div>
       <div className={styles.body}>{children}</div>
     </div>


### PR DESCRIPTION
Fix https://github.com/gravitational/next/issues/867

Added a scope condition for the Admonition component

Usage is the same as in the Details component. If you want to limit by scope, you must specify the `scopeOnly` parameter. And also parameter `scope`, in it you should specify string or array of strings with name of scope/scopes

```
<Admonition type="note" scope={["oss", "enterprise"]} scopeOnly>
    This method only installs the `tsh` client for interacting with Teleport clusters.
    If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
</Admonition>
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202072765206279