### PR TITLE
Add a ScopeLink component

### DIFF
--- a/components/scopelink/ScopeLink.tsx
+++ b/components/scopelink/ScopeLink.tsx
@@ -1,0 +1,27 @@
+import { ScopeType } from "layouts/DocsPage/types";
+import styles from "components/Link/Link.module.css";
+import { DocsContext } from "layouts/DocsPage/context";
+import { useContext } from "react";
+import cn from "classnames";
+
+export interface ScopeLinkProps {
+  scope: ScopeType;
+  children: React.ReactNode;
+}
+
+export const ScopeLink = ({ scope, children }: ScopeLinkProps) => {
+  const { setScope } = useContext(DocsContext);
+
+  return (
+    <a
+      href="#"
+      className={cn(styles.wrapper)}
+      onClick={(e) => {
+        e.preventDefault();
+        setScope(scope);
+      }}
+    >
+      {children}
+    </a>
+  );
+};

--- a/components/scopelink/index.tsx
+++ b/components/scopelink/index.tsx
@@ -1,0 +1,4 @@
+import { ScopeLink, ScopeLinkProps } from "./ScopeLink";
+
+export { ScopeLink };
+export type { ScopeLinkProps };

--- a/layouts/DocsPage/components.tsx
+++ b/layouts/DocsPage/components.tsx
@@ -12,6 +12,7 @@ import {
   TileImage,
 } from "components/Tile";
 import Details from "components/Details";
+import { ScopeLink } from "components/ScopeLink";
 import {
   Code,
   H1,
@@ -74,4 +75,5 @@ export const components = {
   Notice,
   Snippet,
   Details,
+  ScopeLink,
 };


### PR DESCRIPTION
In the docs, there are various guides that are entirely irrelevant for
a user of a particular scope. In these cases, we usually include a
warning at the top of each guide that indicates that the guide is only
relevant for Cloud, Open Source, or Enterprise users. Rather than force
the user to guess that they need to change the value of the scope
picker, the ScopeLink component enables us to add an inline link that
changes the scope of the page. For example:

```html
<Notice
  type="warning"
  scope={["oss"]}
>

  This guide requires Teleport Cloud or Teleport Enterprise.

  View this guide as a <ScopeLink scope="cloud">Teleport Cloud
  user</ScopeLink> or <ScopeLink scope="enterprise">Teleport
  Enterprise user</ScopeLink>.

</Notice>
```