### PR TITLE
Throw a linter error on "bash" code blocks.

### DIFF
--- a/server/remark-code-snippet.test.ts
+++ b/server/remark-code-snippet.test.ts
@@ -164,4 +164,34 @@ Suite("Returns correct error message on multiline command lint", () => {
   );
 });
 
+Suite('Shows a linter warning when using "bash" code blocks', () => {
+  const value = `
+## This is a bash code block:
+
+\`\`\`bash
+$ teleport start;
+\`\`\`
+
+This is a yaml code block:
+
+\`\`\`yaml
+key: value
+key2: value
+\`\`\`
+
+`;
+
+  assert.throws(
+    () =>
+      transformer(
+        {
+          value,
+          path: "/docs/index.mdx",
+        },
+        { lint: true, resolve: false }
+      ),
+    '"bash" code blocks are deprecated. Use "code" instead'
+  );
+});
+
 Suite.run();

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -38,6 +38,8 @@ const RULE_ID = "code-snippet";
 const isCode = (node: MdxastNode): node is MdastCode =>
   node.type === "code" && node.lang === "code";
 
+const isBash = (node: MdastCode): node is MdastCode => node.lang === "bash";
+
 const getCommandNode = (content: string, prefix = "$"): MdxJsxFlowElement => ({
   type: "mdxJsxFlowElement",
   name: "Command",
@@ -99,6 +101,16 @@ export default function remarkCodeSnippet(
   { lint }: RemarkCodeSnippetOptions = { resolve: true }
 ): Transformer {
   return (root, vfile) => {
+    visit(root, isBash, (node: MdastCode, index, parent) => {
+      if (lint) {
+        vfile.fail('"bash" code blocks are deprecated. Use "code" instead');
+      } else {
+        console.error(
+          `ERROR: using a "bash" code block in the file ${vfile.path}, which is deprecated. Use "code" instead.`
+        );
+      }
+    });
+
     visit(root, isCode, (node: MdastCode, index, parent) => {
       const content: string = node.value;
       const codeLines = content.split("\n");


### PR DESCRIPTION
We introduced code blocks with language "code" in order to apply
custom functionality via remark. For older guides that don't include
the "code" language in code blocks, as well as docs contributors who
may not know about the "code" language, it would be helpful to throw
errors on "bash" blocks in the linter.