### PR TITLE
added the bash lang in the remark-code-snippet

### DIFF
--- a/server/fixtures/includes/includes-code-snippet-simplest.mdx
+++ b/server/fixtures/includes/includes-code-snippet-simplest.mdx
@@ -4,3 +4,8 @@
 $ tsh app config --format=uri
 # https://grafana-root.gravitational.io:3080
 ```
+
+```bash
+$ tsh app config --format=uri
+# it's bash lang
+```

--- a/server/fixtures/result/code-snippet-simplest.mdx
+++ b/server/fixtures/result/code-snippet-simplest.mdx
@@ -11,3 +11,15 @@
     https://grafana-root.gravitational.io:3080
   </CommandComment>
 </Snippet>
+
+<Snippet>
+  <Command>
+    <CommandLine data-content="$ ">
+      tsh app config --format=uri
+    </CommandLine>
+  </Command>
+
+  <CommandComment data-type="descr">
+    it's bash lang
+  </CommandComment>
+</Snippet>

--- a/server/mdx-config-docs.ts
+++ b/server/mdx-config-docs.ts
@@ -88,7 +88,7 @@ const config: MdxConfig = {
         },
       },
     ],
-    remarkCodeSnippet, // Plugin for custom code snippets with multiple copy buttons
+    [remarkCodeSnippet, { langs: ["code", "bash"] }], // Plugin for custom code snippets with multiple copy buttons
     remarkGFM, // Adds tables
     remarkImportFiles, // Replaces paths to files with imports
     remarkLinks, // Make links in docs absolute with /ver/X.X included

--- a/server/remark-code-snippet.test.ts
+++ b/server/remark-code-snippet.test.ts
@@ -12,7 +12,10 @@ import remarkCodeSnippet, {
 
 const transformer = (
   options: VFileOptions,
-  pluginOptions: RemarkCodeSnippetOptions = { resolve: true }
+  pluginOptions: RemarkCodeSnippetOptions = {
+    resolve: true,
+    langs: ["code", "bash"],
+  }
 ) =>
   remark()
     .use(mdx)
@@ -137,7 +140,7 @@ Suite("Returns correct error message on heredoc format lint", () => {
           value,
           path: "/docs/index.mdx",
         },
-        { lint: true, resolve: false }
+        { lint: true, resolve: false, langs: ["code", "bash"] }
       ),
     "No closing line for heredoc format"
   );
@@ -158,7 +161,7 @@ Suite("Returns correct error message on multiline command lint", () => {
           value,
           path: "/docs/index.mdx",
         },
-        { lint: true, resolve: false }
+        { lint: true, resolve: false, langs: ["code", "bash"] }
       ),
     "The last string in the multiline command has to be without symbol \\"
   );

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -35,8 +35,10 @@ import { visit } from "unist-util-visit";
 
 const RULE_ID = "code-snippet";
 
-const isCode = (node: MdxastNode): node is MdastCode =>
-  node.type === "code" && node.lang === "code";
+const isCode =
+  (langs: string[]) =>
+  (node: MdxastNode): node is MdastCode =>
+    node.type === "code" && langs.includes(node.lang);
 
 const getCommandNode = (content: string, prefix = "$"): MdxJsxFlowElement => ({
   type: "mdxJsxFlowElement",
@@ -91,15 +93,16 @@ const getCommentNode = (
 });
 
 export interface RemarkCodeSnippetOptions {
+  langs: string[];
   lint?: boolean;
   resolve?: boolean;
 }
 
 export default function remarkCodeSnippet(
-  { lint }: RemarkCodeSnippetOptions = { resolve: true }
+  { langs, lint }: RemarkCodeSnippetOptions = { resolve: true, langs: ["code"] }
 ): Transformer {
   return (root, vfile) => {
-    visit(root, isCode, (node: MdastCode, index, parent) => {
+    visit(root, isCode(langs), (node: MdastCode, index, parent) => {
       const content: string = node.value;
       const codeLines = content.split("\n");
       const children = [];


### PR DESCRIPTION
I added support for quickly changing programming languages, which will be converted into a block of code with the ability to copy commands.

To change languages (delete, add) need to change the array `langs`

```[remarkCodeSnippet, { langs: ["code", "bash"] }]```

https://github.com/gravitational/docs/blob/9751fb8179d3aee33eb9812e35c90dfe026d764d/server/mdx-config-docs.ts#L91