### PR TITLE
Add ability to link to and force open a Details section

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,6 +1,7 @@
 import remarkVariables from "./.build/server/remark-variables.mjs";
 import remarkIncludes from "./.build/server/remark-includes.mjs";
 import remarkCodeSnippet from "./.build/server/remark-code-snippet.mjs";
+import remarkLintDetails from "./.build/server/remark-lint-details.mjs";
 import {
   getVersion,
   getVersionRootPath,
@@ -60,6 +61,7 @@ const configLint = {
       },
     ],
     [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
+    [remarkLintDetails, ["error"]],
   ],
 };
 

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -59,7 +59,7 @@ const configLint = {
         },
       },
     ],
-    [remarkCodeSnippet, { lint: true }],
+    [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
   ],
 };
 

--- a/components/Details/Details.module.css
+++ b/components/Details/Details.module.css
@@ -1,17 +1,17 @@
 .header {
   display: flex;
-  width: 100%;
   align-items: center;
+  width: 100%;
   padding: var(--m-1) 0;
+  font-size: var(--fs-text-md);
+  line-height: var(--lh-sm);
+  font-weight: var(--fw-bold);
+  text-align: left;
+  color: var(--color-darkest);
+  transition: background-color var(--t-interaction);
   border-top-left-radius: var(--r-default);
   border-top-right-radius: var(--r-default);
-  text-align: left;
-  font-size: var(--fs-text-md);
-  font-weight: var(--fw-bold);
-  line-height: var(--lh-sm);
-  color: var(--color-darkest);
   cursor: pointer;
-  transition: background-color var(--t-interaction);
 
   &:hover,
   &:active,
@@ -19,13 +19,34 @@
     color: var(--color-light-purple);
     outline: none;
   }
+
+  &:hover .anchor {
+    display: inline;
+  }
+}
+
+.anchor {
+  display: none;
+  padding-right: var(--m-1);
+  padding-left: var(--m-1);
+  font-weight: var(--fw-regular);
+  text-decoration: none;
+  color: var(--color-light-gray);
+
+  &:hover {
+    color: var(--color-gray);
+  }
+
+  &::before {
+    content: " ¶";
+  }
 }
 
 .icon {
   flex-shrink: 0;
   margin: 0 var(--m-1);
-  transition: transform var(--t-fast);
   transform: rotate(0deg);
+  transition: transform var(--t-fast);
 
   @media (--sm-scr) {
     width: 24px;
@@ -58,8 +79,8 @@
 
 .meta {
   display: flex;
-  flex-shrink: 0;
   align-items: center;
+  flex-shrink: 0;
   margin-right: var(--m-1);
 
   @media (--sm-scr) {
@@ -78,12 +99,12 @@
 .scope {
   margin-right: var(--m-1);
   padding: 0 var(--m-1);
-  border-radius: var(--r-sm);
   font-size: var(--fs-text-xs);
   line-height: 20px;
-  color: var(--color-gray);
   text-transform: uppercase;
+  color: var(--color-gray);
   background-color: var(--color-lightest-gray);
+  border-radius: var(--r-sm);
 
   .wrapper.opened & {
     color: var(--color-white);
@@ -92,9 +113,9 @@
 }
 
 .min {
-  font-weight: regular;
   font-size: var(--fs-text-xs);
   line-height: 20px;
+  font-weight: regular;
   color: var(--color-gray);
 }
 
@@ -113,8 +134,8 @@
 
 .wrapper {
   margin-bottom: var(--m-2);
-  border-radius: var(--r-default);
   background-color: var(--color-white);
+  border-radius: var(--r-default);
 
   &:last-child {
     margin-bottom: 0;

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -62,7 +62,7 @@ export const Details = ({
         isHidden && styles.hidden,
         isOpened && styles.opened
       )}
-      id={!isHidden && detailsId}
+      id={isHidden ? undefined : detailsId}
     >
       <HeadlessButton
         onClick={() => setIsOpened((value) => !value)}

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -41,11 +41,12 @@ export const Details = ({
   const isHiddenInCurrentScope = scopeOnly && !isInCurrentScope;
   const isHidden = isCloudAndNotCurrent || isHiddenInCurrentScope;
   const detailsId = title
-    .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
-    .replace(/[0-9]/g, "")
-    .replaceAll(" ", "-")
-    .toLowerCase();
-  console.log(detailsId);
+    ? title
+        .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
+        .replace(/[0-9]/g, "")
+        .replaceAll(" ", "-")
+        .toLowerCase()
+    : "title";
 
   return (
     <div
@@ -54,7 +55,7 @@ export const Details = ({
         isHidden && styles.hidden,
         isOpened && styles.opened
       )}
-      id={detailsId}
+      id={!isHidden && detailsId}
     >
       <HeadlessButton
         onClick={() => setIsOpened((value) => !value)}
@@ -78,6 +79,7 @@ export const Details = ({
             </div>
           )}
         </div>
+        <a className={styles.anchor} href={`#${detailsId}`} />
       </HeadlessButton>
       <div className={styles.body}>{children}</div>
     </div>

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -29,10 +29,10 @@ export const Details = ({
     scope: currentScope,
     versions: { current, latest },
   } = useContext(DocsContext);
+  const router = useRouter();
   const scopes = useMemo(() => getScopes(scope), [scope]);
   const [isOpened, setIsOpened] = useState<boolean>(Boolean(opened));
   const isInCurrentScope = scopes.includes(currentScope);
-  const router = useRouter();
   const detailsId = title
     ? title
         .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -35,9 +35,9 @@ export const Details = ({
   const isInCurrentScope = scopes.includes(currentScope);
   const detailsId = title
     ? title
-        .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
-        .replace(/[0-9]/g, "")
+        .replace(/[&\/\\#,+()$~%.'":*?<>{}^;\d]/g, "")
         .replace(/\s/g, "-")
+        .replace(/-$/, "")
         .toLowerCase()
     : "title";
   const anchorInPath = getAnchor(router.asPath);

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -8,6 +8,14 @@ import { ScopesType } from "layouts/DocsPage/types";
 import { getAnchor } from "utils/url";
 import styles from "./Details.module.css";
 
+const transformTitleToAnchor = (title: string): string => {
+  return title
+    .replace(/[&\/\\#,+()$~%.'":*?<>{}^;\d]/g, "")
+    .replace(/\s/g, "-")
+    .replace(/-$/, "")
+    .toLowerCase();
+};
+
 export interface DetailsProps {
   scope?: ScopesType;
   title: string;
@@ -33,23 +41,20 @@ export const Details = ({
   const scopes = useMemo(() => getScopes(scope), [scope]);
   const [isOpened, setIsOpened] = useState<boolean>(Boolean(opened));
   const isInCurrentScope = scopes.includes(currentScope);
-  const detailsId = title
-    ? title
-        .replace(/[&\/\\#,+()$~%.'":*?<>{}^;\d]/g, "")
-        .replace(/\s/g, "-")
-        .replace(/-$/, "")
-        .toLowerCase()
-    : "title";
+  const detailsId = title ? transformTitleToAnchor(title) : "title";
   const anchorInPath = getAnchor(router.asPath);
 
   useEffect(() => {
     if (scopes.length) {
       setIsOpened(isInCurrentScope);
     }
+  }, [scopes, isInCurrentScope]);
+
+  useEffect(() => {
     if (anchorInPath === detailsId) {
       setIsOpened(true);
     }
-  }, [scopes, isInCurrentScope, anchorInPath, detailsId]);
+  }, [anchorInPath, detailsId]);
 
   const isCloudAndNotCurrent = scopes.includes("cloud") && current !== latest;
   const isHiddenInCurrentScope = scopeOnly && !isInCurrentScope;

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -44,7 +44,7 @@ export const Details = ({
     ? title
         .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
         .replace(/[0-9]/g, "")
-        .replaceAll(" ", "-")
+        .replace(/\s/g, "-")
         .toLowerCase()
     : "title";
 

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -1,9 +1,11 @@
 import cn from "classnames";
 import { useContext, useEffect, useState, useMemo } from "react";
+import { useRouter } from "next/router";
 import HeadlessButton from "components/HeadlessButton";
 import Icon from "components/Icon";
 import { DocsContext, getScopes } from "layouts/DocsPage/context";
 import { ScopesType } from "layouts/DocsPage/types";
+import { getAnchor } from "utils/url";
 import styles from "./Details.module.css";
 
 export interface DetailsProps {
@@ -30,16 +32,7 @@ export const Details = ({
   const scopes = useMemo(() => getScopes(scope), [scope]);
   const [isOpened, setIsOpened] = useState<boolean>(Boolean(opened));
   const isInCurrentScope = scopes.includes(currentScope);
-
-  useEffect(() => {
-    if (scopes.length) {
-      setIsOpened(isInCurrentScope);
-    }
-  }, [scopes, isInCurrentScope]);
-
-  const isCloudAndNotCurrent = scopes.includes("cloud") && current !== latest;
-  const isHiddenInCurrentScope = scopeOnly && !isInCurrentScope;
-  const isHidden = isCloudAndNotCurrent || isHiddenInCurrentScope;
+  const router = useRouter();
   const detailsId = title
     ? title
         .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
@@ -47,6 +40,20 @@ export const Details = ({
         .replace(/\s/g, "-")
         .toLowerCase()
     : "title";
+  const anchorInPath = getAnchor(router.asPath);
+
+  useEffect(() => {
+    if (scopes.length) {
+      setIsOpened(isInCurrentScope);
+    }
+    if (anchorInPath === detailsId) {
+      setIsOpened(true);
+    }
+  }, [scopes, isInCurrentScope, anchorInPath, detailsId]);
+
+  const isCloudAndNotCurrent = scopes.includes("cloud") && current !== latest;
+  const isHiddenInCurrentScope = scopeOnly && !isInCurrentScope;
+  const isHidden = isCloudAndNotCurrent || isHiddenInCurrentScope;
 
   return (
     <div

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -40,6 +40,12 @@ export const Details = ({
   const isCloudAndNotCurrent = scopes.includes("cloud") && current !== latest;
   const isHiddenInCurrentScope = scopeOnly && !isInCurrentScope;
   const isHidden = isCloudAndNotCurrent || isHiddenInCurrentScope;
+  const detailsId = title
+    .replace(/[&\/\\#,+()$~%.'":*?<>{};]/g, "")
+    .replace(/[0-9]/g, "")
+    .replaceAll(" ", "-")
+    .toLowerCase();
+  console.log(detailsId);
 
   return (
     <div
@@ -48,6 +54,7 @@ export const Details = ({
         isHidden && styles.hidden,
         isOpened && styles.opened
       )}
+      id={detailsId}
     >
       <HeadlessButton
         onClick={() => setIsOpened((value) => !value)}

--- a/server/mdx-config-docs.ts
+++ b/server/mdx-config-docs.ts
@@ -89,7 +89,7 @@ const config: MdxConfig = {
         },
       },
     ],
-    [remarkCodeSnippet, { langs: ["code", "bash"] }], // Plugin for custom code snippets with multiple copy buttons
+    [remarkCodeSnippet, { langs: ["code", "bash"], resolve: true }], // Plugin for custom code snippets with multiple copy buttons
     remarkGFM, // Adds tables
     remarkImportFiles, // Replaces paths to files with imports
     remarkLinks, // Make links in docs absolute with /ver/X.X included

--- a/server/mdx-config-docs.ts
+++ b/server/mdx-config-docs.ts
@@ -93,7 +93,6 @@ const config: MdxConfig = {
     remarkGFM, // Adds tables
     remarkImportFiles, // Replaces paths to files with imports
     remarkLinks, // Make links in docs absolute with /ver/X.X included
-    remarkLintDetails,
   ],
   rehypePlugins: [
     rehypeSlug, // Adds ids to headers to use in anchors

--- a/server/mdx-config-docs.ts
+++ b/server/mdx-config-docs.ts
@@ -19,6 +19,7 @@ import remarkVariables from "./remark-variables";
 import remarkMdxDisableExplicitJsx from "remark-mdx-disable-explicit-jsx";
 import remarkCodeSnippet from "./remark-code-snippet";
 import remarkImportFiles from "./remark-import-files";
+import remarkLintDetails from "./remark-lint-details";
 import { getVersion, getVersionRootPath } from "./docs-helpers";
 import { loadConfig } from "./config-docs";
 import { fetchVideoMeta } from "./youtube-meta";
@@ -92,6 +93,7 @@ const config: MdxConfig = {
     remarkGFM, // Adds tables
     remarkImportFiles, // Replaces paths to files with imports
     remarkLinks, // Make links in docs absolute with /ver/X.X included
+    remarkLintDetails,
   ],
   rehypePlugins: [
     rehypeSlug, // Adds ids to headers to use in anchors

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -100,9 +100,11 @@ export interface RemarkCodeSnippetOptions {
   resolve?: boolean;
 }
 
-export default function remarkCodeSnippet(
-  { langs, lint }: RemarkCodeSnippetOptions = { resolve: true, langs: ["code"] }
-): Transformer {
+export default function remarkCodeSnippet({
+  langs = ["code"],
+  lint = false,
+  resolve = false,
+}: RemarkCodeSnippetOptions): Transformer {
   return (root, vfile) => {
     visit(
       root,

--- a/server/remark-lint-details.ts
+++ b/server/remark-lint-details.ts
@@ -5,23 +5,17 @@ import type { MdxastNode, MdxJsxFlowElement } from "./types-unist";
 const isDetailsSection = (node: MdxastNode): node is MdxJsxFlowElement =>
   node.type === "mdxJsxFlowElement" && node.name === "Details";
 
-const remarkLintDetails = lintRule(
-  {
-    origin: "remark-lint:details",
-    url: "",
-  },
-  (tree, file) => {
-    visit(tree, isDetailsSection, (node: MdxJsxFlowElement) => {
-      if (
-        !node.attributes ||
-        !node.attributes.some((elem) => elem.name === "title")
-      ) {
-        file.fail(
-          "Expected the 'title' prop in the Details component is missing"
-        );
-      }
-    });
-  }
-);
+const remarkLintDetails = lintRule("remark-lint:details", (tree, file) => {
+  visit(tree, isDetailsSection, (node: MdxJsxFlowElement) => {
+    if (
+      !node.attributes ||
+      !node.attributes.some((elem) => elem.name === "title")
+    ) {
+      file.message(
+        "Expected the 'title' prop in the Details component is missing"
+      );
+    }
+  });
+});
 
 export default remarkLintDetails;

--- a/server/remark-lint-details.ts
+++ b/server/remark-lint-details.ts
@@ -1,0 +1,27 @@
+import { lintRule } from "unified-lint-rule";
+import { visit } from "unist-util-visit";
+import type { MdxastNode, MdxJsxFlowElement } from "./types-unist";
+
+const isDetailsSection = (node: MdxastNode): node is MdxJsxFlowElement =>
+  node.type === "mdxJsxFlowElement" && node.name === "Details";
+
+const remarkLintDetails = lintRule(
+  {
+    origin: "remark-lint:details",
+    url: "",
+  },
+  (tree, file) => {
+    visit(tree, isDetailsSection, (node: MdxJsxFlowElement) => {
+      if (
+        !node.attributes ||
+        !node.attributes.some((elem) => elem.name === "title")
+      ) {
+        file.fail(
+          "Expected the 'title' prop in the Details component is missing"
+        );
+      }
+    });
+  }
+);
+
+export default remarkLintDetails;

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -127,3 +127,7 @@ export const getCurrentPageWithScope = (route: string) => {
     ? route.split("/").slice(3).join("/")
     : route.slice(1);
 };
+
+export const getAnchor = (route: string): string => {
+  return route.split("#")[1] || "";
+};


### PR DESCRIPTION
Fix https://github.com/gravitational/next/issues/695

Add ability to link to and force open a Details section.
Added a rule for the linter that the Details component must have a title prop.


https://user-images.githubusercontent.com/41822696/165985918-89fb49ba-364e-41db-9761-25af08da422a.mov



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202072765206286