### PR TITLE
fixing horizontal scrolling in the mobile version

### DIFF
--- a/components/Details/Details.module.css
+++ b/components/Details/Details.module.css
@@ -49,8 +49,9 @@
   transition: transform var(--t-fast);
 
   @media (--sm-scr) {
-    width: 24px;
-    height: 24px;
+    width: 18px;
+    height: 18px;
+    margin: 0 var(--m-1-5) 0 var(--m-1);
   }
 
   @media (--md-scr) {
@@ -75,6 +76,12 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  @media (--sm-scr) {
+    overflow: initial;
+    line-height: 20px;
+    white-space: initial;
+  }
 }
 
 .meta {

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -76,7 +76,7 @@ export const Details = ({
         <Icon name="arrow" className={styles.icon} />
         <div className={styles.description}>
           <div className={styles.title}>{title}</div>
-          {(scopes || min) && (
+          {(scope || min) && (
             <div className={styles.meta}>
               {scopes && (
                 <div className={styles.scopes}>


### PR DESCRIPTION
Fixed horizontal scrolling in the mobile version. 
Also removed empty `div` if no `scope` or `min` prop is passed.


| Was | Became |
| --- | --- |
|<img width="470" alt="Screenshot 2022-05-05 at 09 40 14" src="https://user-images.githubusercontent.com/41822696/166873829-551e768a-86ba-43ed-9bd3-8b4895c2a2b7.png">|<img width="469" alt="Screenshot 2022-05-05 at 09 39 30" src="https://user-images.githubusercontent.com/41822696/166873862-856b992c-b647-4a11-ba3d-f35cd1f9cf23.png">|

