### PR TITLE
Relative link to MDX files in docs partials

### DIFF
--- a/server/mdx-config-docs.ts
+++ b/server/mdx-config-docs.ts
@@ -19,7 +19,6 @@ import remarkVariables from "./remark-variables";
 import remarkMdxDisableExplicitJsx from "remark-mdx-disable-explicit-jsx";
 import remarkCodeSnippet from "./remark-code-snippet";
 import remarkImportFiles from "./remark-import-files";
-import remarkLintDetails from "./remark-lint-details";
 import { getVersion, getVersionRootPath } from "./docs-helpers";
 import { loadConfig } from "./config-docs";
 import { fetchVideoMeta } from "./youtube-meta";

--- a/server/mdx-helpers.ts
+++ b/server/mdx-helpers.ts
@@ -13,7 +13,6 @@ import type {
 } from "./types-unist";
 
 import { createEstree } from "./estree-helpers";
-import stringifyObject from "stringify-object";
 
 export const createMdxjsEsmNode = (value: string): EsmNode => {
   return {

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -26,7 +26,6 @@ import { mdxFromMarkdown } from "mdast-util-mdx";
 import { gfmFromMarkdown } from "mdast-util-gfm";
 import { frontmatterFromMarkdown } from "mdast-util-frontmatter";
 
-import { updateOrCreateAttribute } from "./mdx-helpers";
 import updateMessages from "./update-vfile-messages";
 
 const includeRegexpBase = "\\(!([^!]+)!\\)`?";
@@ -147,7 +146,6 @@ export default function remarkIncludes({
                   grandParent.children.splice(parentIndex, 1, ...tree.children);
                 } else {
                   node.value = result;
-                  console.log("node-value", result);
                 }
               }
 

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -69,9 +69,7 @@ const isInclude = (node: Code | Text): node is Code | Text =>
 
 const addDataToLinks = (node, path: string) => {
   if (node.type === "link") {
-    if (!node.data) {
-      node.data = { partialPath: path };
-    }
+    node.data = { partialPath: path };
   }
   node.children?.forEach((child) => addDataToLinks(child, path));
 };

--- a/server/remark-links.ts
+++ b/server/remark-links.ts
@@ -79,11 +79,7 @@ function handlePartialLink<T>(
   node: MdxastNode,
   mdxPath: string
 ): T | string {
-  if (
-    typeof href !== "string" ||
-    href.at(0) === "/" ||
-    !node.data?.partialPath
-  ) {
+  if (typeof href !== "string" || href[0] === "/" || !node.data?.partialPath) {
     return href;
   }
 


### PR DESCRIPTION
correct relative paths resolving in partial docs
 i.e. start realtive paths from the partial file directory, not from place where it is being inserted
example:
 main file: `docs/page/1.mdx`
 partial:   `docs/includes/headers/1.mdx`
 
With this utility path like that
 `../getting-started`
in partial will be pointing to
 `docs/partials/getting-started`
and without:
 `docs/getting-started`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202102564588806