### PR TITLE
Allow link hrefs with a scope query param

### DIFF
--- a/components/Link/hooks.ts
+++ b/components/Link/hooks.ts
@@ -1,6 +1,7 @@
 import { resolve } from "url";
 import { useRouter } from "next/router";
 import { useContext } from "react";
+import { ScopeType, scopeValues } from "layouts/DocsPage/types";
 import {
   normalizePath,
   splitPath,
@@ -31,7 +32,18 @@ export const useNormalizedHref = (href: string) => {
     ? href.substring(basePath.length)
     : href;
 
-  const { scope } = useContext(DocsContext);
+  let scope: ScopeType = useContext(DocsContext).scope;
+
+  const { query } = splitPath(href);
+
+  // If a valid scope is provided via query parameter, adjust the
+  // link to navigate to that scope.
+  if (
+    query.hasOwnProperty("scope") &&
+    scopeValues.includes(query.scope as ScopeType)
+  ) {
+    scope = query["scope"] as ScopeType;
+  }
 
   if (
     isHash(noBaseHref) ||


### PR DESCRIPTION
Closes #35
Closes #33
See https://github.com/gravitational/teleport/issues/11383

Previously, the Link component would always set the "scope" query
parameter in its href to the current value of DocsContext.scope.
I wanted to make it possible to link to other scopes, allowing readers
who are interested in another edition of Teleport to read content
intended for that edition.

We could add explicit links to different
scopes in, for example, warnings at the top of scope-irrelevant
pages or in introduction pages to sections that are only helpful for
a specific Teleport edition (e.g., the Enterprise section).

This change edits useNormalizedHref to add a "scope" value to the
href's query if the input href has a "scope" key and the value is
a valid scope name ("oss", "cloud", or "enterprise").