### PR TITLE
Extend scope syntax

### DIFF
--- a/components/Admonition/Admonition.tsx
+++ b/components/Admonition/Admonition.tsx
@@ -1,7 +1,6 @@
 import cn from "classnames";
 import { useContext, useMemo } from "react";
 import { DocsContext, getScopes } from "layouts/DocsPage/context";
-import { ScopesType } from "layouts/DocsPage/types";
 import styles from "./Admonition.module.css";
 
 const capitalize = (text: string): string =>
@@ -14,7 +13,7 @@ export interface AdmonitionProps {
   title: string;
   children: React.ReactNode;
   scopeOnly: boolean;
-  scope?: ScopesType;
+  scope?: string | string[];
 }
 
 const Admonition = ({

--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import HeadlessButton from "components/HeadlessButton";
 import Icon from "components/Icon";
 import { DocsContext, getScopes } from "layouts/DocsPage/context";
-import { ScopesType } from "layouts/DocsPage/types";
 import { getAnchor } from "utils/url";
 import styles from "./Details.module.css";
 
@@ -17,7 +16,7 @@ const transformTitleToAnchor = (title: string): string => {
 };
 
 export interface DetailsProps {
-  scope?: ScopesType;
+  scope?: string | string[];
   title: string;
   opened?: boolean;
   scopeOnly: boolean;

--- a/components/ScopedBlock/ScopedBlock.tsx
+++ b/components/ScopedBlock/ScopedBlock.tsx
@@ -1,22 +1,15 @@
-import { useRouter } from "next/router";
-import { getScopeFromUrl } from "layouts/DocsPage/context";
-import { ScopesType } from "layouts/DocsPage/types";
+import { useMemo, useContext } from "react";
+import { DocsContext, getScopes } from "layouts/DocsPage/context";
 
 interface ScopedBlockProps {
-  scope: ScopesType;
+  scope: string | string[];
   children: React.ReactNode;
 }
 
 export const ScopedBlock = ({ scope, children }: ScopedBlockProps) => {
-  const router = useRouter();
-  const urlScope = getScopeFromUrl(router.asPath);
-  let isDisplayedBlock: boolean;
+  const { scope: currentScope } = useContext(DocsContext);
+  const scopes = useMemo(() => getScopes(scope), [scope]);
+  const isInCurrentScope = scopes.includes(currentScope);
 
-  if (Array.isArray(scope)) {
-    isDisplayedBlock = scope.some((propsScope) => propsScope === urlScope);
-  } else {
-    isDisplayedBlock = scope === urlScope;
-  }
-
-  return isDisplayedBlock ? <>{children}</> : null;
+  return isInCurrentScope ? <>{children}</> : null;
 };

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -10,7 +10,6 @@ import {
 import HeadlessButton from "components/HeadlessButton";
 import { VersionWarning } from "layouts/DocsPage";
 import { DocsContext, getScopes } from "layouts/DocsPage/context";
-import { ScopesType } from "layouts/DocsPage/types";
 import styles from "./Tabs.module.css";
 
 const getSelectedLabel = (
@@ -23,7 +22,7 @@ const getSelectedLabel = (
 
 export interface TabItemProps {
   selected?: boolean;
-  scope?: ScopesType;
+  scope?: string | string[];
   label: string;
   children: React.ReactNode;
 }

--- a/layouts/DocsPage/context.tsx
+++ b/layouts/DocsPage/context.tsx
@@ -3,13 +3,20 @@ import { createContext, useState, useEffect } from "react";
 import { splitPath, buildPath } from "utils/url";
 import { VersionsInfo, scopeValues, ScopeType } from "./types";
 
-export const getScopes = (scope?: ScopeType | ScopeType[]) => {
-  if (!scope) {
-    return [];
-  } else if (Array.isArray(scope)) {
-    return scope;
+export const getScopes = (scopes?: string | string[]): ScopeType[] => {
+  if (typeof scopes === "string") {
+    return scopes
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter((scope) =>
+        scopeValues.includes(scope as ScopeType)
+      ) as ScopeType[];
+  } else if (Array.isArray(scopes)) {
+    return scopes.filter((scope) =>
+      scopeValues.includes(scope as ScopeType)
+    ) as ScopeType[];
   } else {
-    return [scope];
+    return [];
   }
 };
 


### PR DESCRIPTION
This PR adds new syntax to the scope param in docs components.

In addition to `scope="oss"` and `scope={["oss", "cloud"]}` we now can write scope as `scope="oss,cloud"`.

Why we need it: If we want to switch docs from mdx to markdown, we need to make all params in components to be the strings. This PR will allow us to update the docs without breaking backward compatibility.