### PR TITLE
Add remark-lint-frontmatter

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -2,6 +2,7 @@ import remarkVariables from "./.build/server/remark-variables.mjs";
 import remarkIncludes from "./.build/server/remark-includes.mjs";
 import remarkCodeSnippet from "./.build/server/remark-code-snippet.mjs";
 import remarkLintDetails from "./.build/server/remark-lint-details.mjs";
+import remarkLintFrontmatter from "./.build/server/remark-lint-frontmatter.mjs";
 import {
   getVersion,
   getVersionRootPath,
@@ -62,6 +63,7 @@ const configLint = {
     ],
     [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
     [remarkLintDetails, ["error"]],
+    [remarkLintFrontmatter, ["error"]],
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "tsm": "^2.2.1",
     "typescript": "^4.6.3",
     "unified": "^10.1.2",
+    "unified-lint-rule": "^2.1.1",
     "unist-util-find": "^1.0.2",
     "unist-util-visit": "4.1.0",
     "unist-util-visit-parents": "^5.1.0",

--- a/server/fixtures/lint-frontmatter/base-desc.md
+++ b/server/fixtures/lint-frontmatter/base-desc.md
@@ -1,0 +1,4 @@
+---
+title: Title 2
+description: Description 1
+---

--- a/server/fixtures/lint-frontmatter/base-title.md
+++ b/server/fixtures/lint-frontmatter/base-title.md
@@ -1,0 +1,4 @@
+---
+title: Title 1
+description: Description 2
+---

--- a/server/fixtures/lint-frontmatter/base.md
+++ b/server/fixtures/lint-frontmatter/base.md
@@ -1,0 +1,4 @@
+---
+title: Title 1
+description: Description 1
+---

--- a/server/fixtures/lint-frontmatter/new.md
+++ b/server/fixtures/lint-frontmatter/new.md
@@ -1,0 +1,4 @@
+---
+title: Title 3
+description: Description 3
+---

--- a/server/remark-lint-frontmatter.test.ts
+++ b/server/remark-lint-frontmatter.test.ts
@@ -1,0 +1,52 @@
+import type { VFile } from "vfile";
+
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+
+import { readSync } from "to-vfile";
+import { resolve } from "path";
+import { remark } from "remark";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkLintFrontmatter from "./remark-lint-frontmatter";
+
+const transformer = (path: string) => {
+  const file = readSync(resolve(path));
+
+  return remark()
+    .use(remarkFrontmatter)
+    .use(remarkLintFrontmatter)
+    .processSync(file);
+};
+
+const getErorrs = (result: VFile) =>
+  result.messages.map(({ message }) => message);
+
+const base = transformer("server/fixtures/lint-frontmatter/base.md"); // Will add baseline to cache
+
+const Suite = suite("server/remark-lint-frontmatter");
+
+Suite("Detects error in title", () => {
+  const result = transformer("server/fixtures/lint-frontmatter/base-title.md");
+
+  const expectedErrors = [`Title "Title 1" is already used in "${base.path}"`];
+
+  assert.equal(getErorrs(result), expectedErrors);
+});
+
+Suite("Detects error in description", () => {
+  const result = transformer("server/fixtures/lint-frontmatter/base-desc.md");
+
+  const expectedErrors = [
+    `Description "Description 1" is already used in "${base.path}"`,
+  ];
+
+  assert.equal(getErorrs(result), expectedErrors);
+});
+
+Suite("Does not fire if no matches", () => {
+  const result = transformer("server/fixtures/lint-frontmatter/new.md");
+
+  assert.equal(getErorrs(result), []);
+});
+
+Suite.run();

--- a/server/remark-lint-frontmatter.test.ts
+++ b/server/remark-lint-frontmatter.test.ts
@@ -18,7 +18,7 @@ const transformer = (path: string) => {
     .processSync(file);
 };
 
-const getErorrs = (result: VFile) =>
+const getErrors = (result: VFile) =>
   result.messages.map(({ message }) => message);
 
 const base = transformer("server/fixtures/lint-frontmatter/base.md"); // Will add baseline to cache
@@ -30,7 +30,7 @@ Suite("Detects error in title", () => {
 
   const expectedErrors = [`Title "Title 1" is already used in "${base.path}"`];
 
-  assert.equal(getErorrs(result), expectedErrors);
+  assert.equal(getErrors(result), expectedErrors);
 });
 
 Suite("Detects error in description", () => {
@@ -40,13 +40,13 @@ Suite("Detects error in description", () => {
     `Description "Description 1" is already used in "${base.path}"`,
   ];
 
-  assert.equal(getErorrs(result), expectedErrors);
+  assert.equal(getErrors(result), expectedErrors);
 });
 
 Suite("Does not fire if no matches", () => {
   const result = transformer("server/fixtures/lint-frontmatter/new.md");
 
-  assert.equal(getErorrs(result), []);
+  assert.equal(getErrors(result), []);
 });
 
 Suite.run();

--- a/server/remark-lint-frontmatter.ts
+++ b/server/remark-lint-frontmatter.ts
@@ -1,0 +1,65 @@
+import type { Node as UnistNode, Parent as UnistParent } from "unist";
+import type { VFile } from "vfile";
+
+import { lintRule } from "unified-lint-rule";
+import find from "unist-util-find";
+import yaml from "js-yaml";
+
+interface Meta {
+  title?: string;
+  description?: string;
+}
+
+let cache: Record<string, Meta> = {};
+
+const hasMatchingFieldValue = (field: string) => (value: string) => {
+  if (!value) {
+    return null;
+  }
+
+  const entry = Object.entries(cache).find(
+    ([_, meta]) => meta[field] && meta[field].trim() === value.trim()
+  );
+
+  return entry ? entry[0] : null;
+};
+
+const hasMatchingTitle = hasMatchingFieldValue("title");
+const hasMatchingDescription = hasMatchingFieldValue("description");
+
+const remarkLintFrontmatter = lintRule(
+  "remark-lint:frontmatter",
+  (root: UnistParent, file: VFile) => {
+    const node = find(root, (node: UnistNode) => node.type === "yaml");
+
+    if (!node) {
+      return;
+    }
+
+    const meta = yaml.load(node.value as string) as Meta;
+
+    const { title, description } = meta;
+
+    const pathWithTitle = hasMatchingTitle(title);
+
+    if (pathWithTitle) {
+      file.fail(`Title "${title}" is already used in "${pathWithTitle}"`);
+    }
+
+    const pathWithDecription = hasMatchingDescription(description);
+
+    if (pathWithDecription) {
+      file.fail(
+        `Description "${description}" is already used in "${pathWithDecription}"`
+      );
+    }
+
+    cache[file.path] = meta;
+  }
+);
+
+export default remarkLintFrontmatter;
+
+export const cleanCache = () => {
+  cache = {};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8606,7 +8606,7 @@ unified-lint-rule@^1.0.4:
   dependencies:
     wrapped "^1.0.1"
 
-unified-lint-rule@^2.0.0:
+unified-lint-rule@^2.0.0, unified-lint-rule@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/unified-lint-rule/-/unified-lint-rule-2.1.1.tgz#2363f27064f0b44675d11119bb573a738e346f24"
   integrity sha512-vsLHyLZFstqtGse2gvrGwasOmH8M2y+r2kQMoDSWzSqUkQx2MjHjvZuGSv5FUaiv4RQO1bHRajy7lSGp7XWq5A==


### PR DESCRIPTION
This plugin checks for duplicate `title` and `description` using simple in-memory cache.

To run from cli use command: `yarn remark 'content/10.0/docs/pages/**/*.mdx' -fq`.

To run programmatically – check tests for examples.

To reset cache if needed (e. g. for more detailed tests) use: `cleanCache()` function.
