### PR TITLE
Fixes errors with `process.env` destructuring

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import "styles/fonts-lato.css";
 import "styles/global.css";
 import "styles/algolia-search.css";
 
-const { NEXT_PUBLIC_GTM_ID } = process.env;
+const NEXT_PUBLIC_GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
 interface dataLayerItem {
   [key: string]: unknown;
@@ -25,7 +25,7 @@ declare global {
 const Analytics = () => {
   return (
     <>
-      <Script id="dataLayer">
+      <Script id="add_dataLayer">
         {`window.dataLayer = window.dataLayer || []`}
       </Script>
       {NEXT_PUBLIC_GTM_ID && (

--- a/server/docs-helpers.ts
+++ b/server/docs-helpers.ts
@@ -9,7 +9,7 @@ import { loadConfig as loadDocsConfig } from "./config-docs";
 import { loadConfig as loadSiteConfig } from "./config-site";
 
 const { branches, versions, latest } = loadSiteConfig();
-const { NEXT_PUBLIC_GITHUB_DOCS } = process.env;
+const NEXT_PUBLIC_GITHUB_DOCS = process.env.NEXT_PUBLIC_GITHUB_DOCS;
 
 export const getVersion = (filepath: string) => {
   const result = /content\/([^/]+)\/docs\//.exec(filepath);

--- a/server/youtube-meta.ts
+++ b/server/youtube-meta.ts
@@ -4,7 +4,7 @@
 
 import got from "got";
 
-const { YOUTUBE_API_KEY } = process.env;
+const YOUTUBE_API_KEY = process.env.YOUTUBE_API_KEY;
 
 const REQUEST_PATH = "videos";
 const YOUTUBE_URL = "https://www.youtube.com/watch";


### PR DESCRIPTION
- fixed process.env destructuring and updated script id
- this is the `docs` version of gravitational/next#1210