### PR TITLE
fixed a version switching

### DIFF
--- a/utils/url.ts
+++ b/utils/url.ts
@@ -122,11 +122,11 @@ export const isLocalAssetFile = (
   );
 };
 
-export const getCurrentPageWithoutVers = (route: string) => {
-  const currentPath = splitPath(route).path;
-  return currentPath.startsWith("/ver/")
-    ? currentPath.split("/").slice(3).join("/")
-    : currentPath.slice(1);
+export const getPathWithoutVersion = (route: string) => {
+  const path = splitPath(route).path;
+  return path.startsWith("/ver/")
+    ? path.split("/").slice(3).join("/")
+    : path.slice(1);
 };
 
 export const getAnchor = (route: string): string => {

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -122,10 +122,11 @@ export const isLocalAssetFile = (
   );
 };
 
-export const getCurrentPageWithScope = (route: string) => {
-  return route.startsWith("/ver/")
-    ? route.split("/").slice(3).join("/")
-    : route.slice(1);
+export const getCurrentPageWithoutVers = (route: string) => {
+  const currentPath = splitPath(route).path;
+  return currentPath.startsWith("/ver/")
+    ? currentPath.split("/").slice(3).join("/")
+    : currentPath.slice(1);
 };
 
 export const getAnchor = (route: string): string => {

--- a/utils/useFindDestinationPath.ts
+++ b/utils/useFindDestinationPath.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { getCurrentPageWithoutVers } from "utils/url";
+import { getPathWithoutVersion } from "utils/url";
 import type {
   LinkWithRedirectList,
   VersionsInfo,
@@ -155,12 +155,12 @@ const findExistingPage = ({
     }
   }
 
-  if (foundElement) {
-    if (foundElement.path.startsWith("/ver/")) {
-      return foundElement.path;
-    }
+  if (foundElement?.path.startsWith("/ver/")) {
+    return foundElement.path;
+  } else if (foundElement) {
     return `/ver/${version}${foundElement.path}`;
   }
+
   return `/ver/${version}/`;
 };
 
@@ -172,7 +172,7 @@ export function useFindDestinationPath(versions: VersionsInfo) {
 
   return useCallback(
     (versDestination) => {
-      const targetPageWithVersion = `/ver/${versDestination}/${getCurrentPageWithoutVers(
+      const targetPageWithVersion = `/ver/${versDestination}/${getPathWithoutVersion(
         router.asPath
       )}`;
       let path = "/";

--- a/utils/useFindDestinationPath.ts
+++ b/utils/useFindDestinationPath.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { getCurrentPageWithScope } from "utils/url";
+import { getCurrentPageWithoutVers } from "utils/url";
 import type {
   LinkWithRedirectList,
   VersionsInfo,
@@ -155,7 +155,13 @@ const findExistingPage = ({
     }
   }
 
-  return foundElement ? foundElement.path : `/ver/${version}/`;
+  if (foundElement) {
+    if (foundElement.path.startsWith("/ver/")) {
+      return foundElement.path;
+    }
+    return `/ver/${version}${foundElement.path}`;
+  }
+  return `/ver/${version}/`;
 };
 
 export function useFindDestinationPath(versions: VersionsInfo) {
@@ -166,7 +172,7 @@ export function useFindDestinationPath(versions: VersionsInfo) {
 
   return useCallback(
     (versDestination) => {
-      const targetPageWithVersion = `/ver/${versDestination}/${getCurrentPageWithScope(
+      const targetPageWithVersion = `/ver/${versDestination}/${getCurrentPageWithoutVers(
         router.asPath
       )}`;
       let path = "/";


### PR DESCRIPTION
_The following issues have been fixed:_

1. There was a problem with changing the version if a scope other than OpenSource was selected. Specifically - the selected page was not saved, the page was reset to default.

**was**

https://user-images.githubusercontent.com/41822696/171356612-660ad059-eef5-4fd8-b30e-2be7c105b189.mov


**became**

https://user-images.githubusercontent.com/41822696/171356678-f871c010-6cd2-4a6d-b20f-cf51b8bf4ca3.mov


2. When I changed the version to the current version, the page was reloaded. In the development version - in the console there was an error that no page was found in the chunk. If a scope other than OpenSource was selected, it was reset to OpenSource

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202114450279370