### PR TITLE
added the dropdown labels option

### DIFF
--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -18,6 +18,9 @@ import styles from "./Tabs.module.css";
  * 
  * - If at least one TabsItem has an inDropdown prop,
  * then TabsItems without an inDropdown prop will be displayed in all Dropdown options.
+ * - You can replace the Tab Labels with a dropdown list. To do this, add the prop 
+ * `dropdownView` to the Tabs component. 
+ * <Tabs dropdownView> ... </Tabs>
  * 
  * <Tabs dropdownCaption="Installing Teleport" dropdownSelected="gatsby">
     <TabItem label="Download" options="gatsby, js">
@@ -77,6 +80,7 @@ export const Tabs = ({
   children,
   dropdownCaption,
   dropdownSelected,
+  dropdownView,
 }: TabsProps) => {
   const {
     scope,
@@ -155,10 +159,32 @@ export const Tabs = ({
   }, [scope, childTabs]);
 
   const visibleTabs = dropdownVarsArr.filter((t) => t !== DEFAULT_DROPDOWN);
+  const dropOptions = tabsMeta.map((item) => item.label);
+
+  const labels = dropdownView ? (
+    <div className={styles["drop-wrapper"]}>
+      <p className={styles["drop-title"]}>
+        {dropdownCaption || "Choose one of the options"}
+      </p>
+      <Dropdown
+        className={styles.dropdown}
+        value={currentTab}
+        options={dropOptions}
+        onChange={setCurrentTab}
+      />
+    </div>
+  ) : (
+    <TabLabelList
+      visibleTabs={visibleTabs}
+      tabsMeta={tabsMeta}
+      currentTab={currentTab}
+      onClick={setCurrentTab}
+    />
+  );
 
   return (
     <div className={styles.wrapper}>
-      {Boolean(visibleTabs.length) && (
+      {Boolean(visibleTabs.length) && !dropdownView && (
         <div className={styles["drop-wrapper"]}>
           <p className={styles["drop-title"]}>
             {dropdownCaption || "Choose one of the options"}
@@ -171,12 +197,8 @@ export const Tabs = ({
           />
         </div>
       )}
-      <TabLabelList
-        visibleTabs={visibleTabs}
-        tabsMeta={tabsMeta}
-        currentTab={currentTab}
-        onClick={setCurrentTab}
-      />
+      {labels}
+
       <TabItemList
         childTabs={childTabs}
         currentTab={currentTab}

--- a/components/Tabs/types.ts
+++ b/components/Tabs/types.ts
@@ -25,6 +25,7 @@ export interface TabsProps {
   children: React.ReactNode;
   dropdownCaption?: string;
   dropdownSelected?: string;
+  dropdownView?: boolean;
 }
 
 export interface TabItemsListProps {


### PR DESCRIPTION
Previously it was possible to make labels for tabs only with buttons. Added that labels can now be in dropdown.

|early the labels only look like this | now the labels may look like this|
|---------------------------------| ------------------------------------|
| <img width="440" alt="Screenshot 2022-06-02 at 14 54 07" src="https://user-images.githubusercontent.com/41822696/171634228-172decb3-ffa6-48db-ac54-9d5ba9430c0b.png">| <img width="440" alt="Screenshot 2022-06-02 at 15 00 02" src="https://user-images.githubusercontent.com/41822696/171634486-f87eb180-f97d-4abd-821d-d3948b2f1e58.png">|

To display the labels in the dropdown, you need to add a prop `dropdownView` to the Tabs component. An additional prop `dropdownCaption` can also be added. In which you can specify the title to the dropdown. If you don't specify the `dropdownCaption` prop, the default text will be "Choose one of the options".
The prop `selected` in `<TabItem label="Homebrew">` means that this tab will initially be selected.

Example of a component with dropdown headers

```<Tabs dropdownView>
  <TabItem label="Download">
    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=mac) (tsh client only, signed) file, double-click to run the Installer.
  </TabItem>

  <TabItem label="Homebrew" selected>
    ```code
    $ brew install teleport
    ```
  </TabItem>

  <TabItem label="Terminal">
    ```code
    $ curl -O https://get.gravitational.com/teleport-(=teleport.version=).pkg
    $ sudo installer -pkg teleport-(=teleport.version=).pkg -target / # Installs on Macintosh HD
    # Password:
    # installer: Package name is teleport-(=teleport.version=)
    # installer: Upgrading at base path /
    # installer: The upgrade was successful.
    $ which teleport
    # /usr/local/bin/teleport
    ```
  </TabItem>
</Tabs>
```


https://user-images.githubusercontent.com/41822696/171637801-dceb152f-9b25-4893-a894-78076fcc4b9a.mov


