### PR TITLE
Docs image CI/CD script

### DIFF
--- a/.cloudbuild/image.yaml
+++ b/.cloudbuild/image.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    env:
+      - DOCKER_BUILDKIT=1
+      - DOCKER_REGISTRY=quay.io
+      - DOCKER_REPOSITORY=gravitational/docs
+      - DOCKER_TAG=latest
+    secretEnv:
+      - QUAYIO_DOCKER_USERNAME
+      - QUAYIO_DOCKER_PASSWORD
+    script: .cloudbuild/publish-image.sh 
+availableSecrets:
+  secretManager:
+  - versionName: projects/771512790633/secrets/ci_docs-quay_io_username/versions/1
+    env: QUAYIO_DOCKER_USERNAME
+  - versionName: projects/771512790633/secrets/ci_docs_quay_io_password/versions/1
+    env: QUAYIO_DOCKER_PASSWORD
+
+  

--- a/.cloudbuild/image.yaml
+++ b/.cloudbuild/image.yaml
@@ -15,5 +15,3 @@ availableSecrets:
     env: QUAYIO_DOCKER_USERNAME
   - versionName: projects/771512790633/secrets/ci_docs_quay_io_password/versions/1
     env: QUAYIO_DOCKER_PASSWORD
-
-  

--- a/.cloudbuild/image.yaml
+++ b/.cloudbuild/image.yaml
@@ -15,3 +15,4 @@ availableSecrets:
     env: QUAYIO_DOCKER_USERNAME
   - versionName: projects/771512790633/secrets/ci_docs_quay_io_password/versions/1
     env: QUAYIO_DOCKER_PASSWORD
+    

--- a/.cloudbuild/publish-image.sh
+++ b/.cloudbuild/publish-image.sh
@@ -1,0 +1,7 @@
+#! /bin/env bash
+set -e
+IMAGE_NAME=$DOCKER_REGISTRY/$DOCKER_REPOSITORY:$DOCKER_TAG
+echo Building $IMAGE_NAME
+DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME .
+echo $QUAYIO_DOCKER_PASSWORD | docker login -u $QUAYIO_DOCKER_USERNAME --password-stdin $DOCKER_REGISTRY
+docker push $IMAGE_NAME


### PR DESCRIPTION
Adds a build script that will construct and publish the `docs` image to
`quay.io`. This build script will be triggered by Google Cloud Build
on a push to `main`.

The upshot of this script is that the image used by Teleoprt CI to
run its doctests will be automatically updated every time a PR is
merged in this repository.

See-Also: https://github.com/gravitational/teleport/issues/13457