### PR TITLE
Run validate-links after remarkVariables

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -44,7 +44,6 @@ const configLint = {
     "lint-ordered-list-marker-value",
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
-    ["validate-links", { repository: false }],
     [
       remarkIncludes, // Lints (!include.ext!) syntax
       {
@@ -61,6 +60,10 @@ const configLint = {
         },
       },
     ],
+    // validate-links must be run after remarkVariables since some links
+    // include variables in their references, e.g., 
+    // [CM-08 Information System Component Inventory]((=fedramp.control_url=)CM-8)
+    ["validate-links", { repository: false }],
     [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
     [remarkLintDetails, ["error"]],
     [remarkLintFrontmatter, ["error"]],


### PR DESCRIPTION
Linting via remark was failing because some link URLs included variables
in the link target, e.g.:

`[CM-08]((=fedramp.control_url=)CM-8)`, where the `fedramp.control_url`
variable value is a valid URL that includes a query string containing
the value after the variable.

validate-links would be run before remarkVariables, so links like this
would fail the linter since the variables were not being resolved.

This change runs validate-links after remarkVariables to ensure the
linter can check fully evaluated links.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202483794575373