### PR TITLE
added processing of local links with scoping

### DIFF
--- a/server/remark-links.ts
+++ b/server/remark-links.ts
@@ -35,7 +35,7 @@ const updateHref = (basename: string, href: Href) => {
   }
   const isIndex = basename.match(/^index.mdx?$/);
   const prefix = isIndex ? "./" : "../";
-  const newHref = href.replace(/(\/)?(index)?\.mdx\/?/, "/");
+  const newHref = href.replace(/(\/)?(index)?\.mdx?\/?/, "/");
   const startsWithDot = /^\./.test(newHref);
   const startsWithSlash = /^\//.test(newHref);
 

--- a/server/remark-links.ts
+++ b/server/remark-links.ts
@@ -35,7 +35,7 @@ const updateHref = (basename: string, href: Href) => {
   }
   const isIndex = basename.match(/^index.mdx?$/);
   const prefix = isIndex ? "./" : "../";
-  const newHref = href.replace(/(\/)?(index)?\.mdx?/, "/");
+  const newHref = href.replace(/(\/)?(index)?\.mdx\/?/, "/");
   const startsWithDot = /^\./.test(newHref);
   const startsWithSlash = /^\//.test(newHref);
 


### PR DESCRIPTION
The remark-links plugin was not expected to contain a local link like `./enterprise/introduction.mdx/?scope=enterprise`. Specifically, it was not expected that `/` could follow `.mdx`. I added the handling of such a case

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202484213799943