### PR TITLE
Improve search result display

### DIFF
--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -52,8 +52,16 @@ const SearchAutocomplete = (props) => {
 function ProductItem({ hit }) {
   let foundHeader = "";
   let foundContent = "";
+  console.log(hit);
 
-  if (hit._snippetResult.headers?.length) {
+  if (
+    hit._snippetResult.content?.matchLevel === "full" ||
+    hit._snippetResult.headers?.matchLevel === "full"
+  ) {
+    hit._snippetResult.headers?.matchLevel
+      ? (foundHeader = hit._snippetResult.headers[0].value)
+      : (foundContent = hit._snippetResult.content.value);
+  } else if (hit._snippetResult.headers?.length) {
     foundHeader = hit._snippetResult.headers[0].value;
   } else if (hit._snippetResult.content) {
     foundContent = hit._snippetResult.content.value;

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -57,11 +57,13 @@ function ProductItem({ hit }) {
   );
 
   if (hit._snippetResult.content?.matchLevel === "full" || exactHeaderMatch) {
-    exactHeaderMatch
-      ? (foundHeader = exactHeaderMatch.value)
-      : (foundContent = hit._snippetResult.content.value);
+    if (exactHeaderMatch) {
+      foundHeader = exactHeaderMatch.value;
+    } else {
+      foundContent = hit._snippetResult.content.value;
+    }
   } else if (
-    hit._highlightResult.headers?.matchedWords?.length >
+    hit._highlightResult.headers[0]?.matchedWords?.length >
     hit._highlightResult.content?.matchedWords?.length
   ) {
     foundHeader = hit._snippetResult.headers[0].value;

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -52,18 +52,20 @@ const SearchAutocomplete = (props) => {
 function ProductItem({ hit }) {
   let foundHeader = "";
   let foundContent = "";
-  console.log(hit);
+  const exactHeaderMatch = hit._snippetResult.headers?.find(
+    (header) => header.matchLevel === "full"
+  );
 
-  if (
-    hit._snippetResult.content?.matchLevel === "full" ||
-    hit._snippetResult.headers?.matchLevel === "full"
-  ) {
-    hit._snippetResult.headers?.matchLevel
-      ? (foundHeader = hit._snippetResult.headers[0].value)
+  if (hit._snippetResult.content?.matchLevel === "full" || exactHeaderMatch) {
+    exactHeaderMatch
+      ? (foundHeader = exactHeaderMatch.value)
       : (foundContent = hit._snippetResult.content.value);
-  } else if (hit._snippetResult.headers?.length) {
+  } else if (
+    hit._highlightResult.headers?.matchedWords?.length >
+    hit._highlightResult.content?.matchedWords?.length
+  ) {
     foundHeader = hit._snippetResult.headers[0].value;
-  } else if (hit._snippetResult.content) {
+  } else {
     foundContent = hit._snippetResult.content.value;
   }
 

--- a/pages/api/search/index.ts
+++ b/pages/api/search/index.ts
@@ -23,7 +23,7 @@ export default async function handler(
       filters: `docs_ver:${docsVer}`,
       restrictHighlightAndSnippetArrays: true,
       attributesToHighlight: ["content", "headers"],
-      attributesToSnippet: ["content:30", "headers"],
+      attributesToSnippet: ["content:20", "headers"],
       snippetEllipsisText: "…",
       highlightPreTag: "<b class='found-part'>",
       highlightPostTag: "</b>",
@@ -35,6 +35,9 @@ export default async function handler(
       const title = hit.title?.includes("|")
         ? hit.title.split("|")[0].trim()
         : hit.title;
+      hit._highlightResult.headers?.sort(
+        (a, b) => b.matchedWords.length - a.matchedWords.length
+      );
       return { ...hit, title };
     });
     res.status(200).json(finishResult);


### PR DESCRIPTION
Closes #72 
Closes https://github.com/gravitational/next/issues/1242

Changed the search results window. Added sorting to the headers by the number of matches. Results with a full match are displayed first in the output window.
In the configurator crawler:
- Added tags `span`, `pre` and `code` for content.
- added a filter to exclude comments in the search code
- added a space at the beginning of the command line to prevent the lines from sticking together

Search commands now works correctly

<img width="525" alt="Screenshot 2022-07-01 at 15 27 28" src="https://user-images.githubusercontent.com/41822696/176896023-79281b1f-5b34-4928-b3a0-b2fe5f5d0910.png">

<img width="526" alt="Screenshot 2022-07-01 at 15 28 30" src="https://user-images.githubusercontent.com/41822696/176896069-e361eaf6-857d-41e7-a957-cf2e1beda707.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202512727506839