### PR TITLE
Create additional build for amazon ECR

### DIFF
--- a/.cloudbuild/image-ecr.yaml
+++ b/.cloudbuild/image-ecr.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    secretEnv:
+      - STAGING_DOCS_ECR_KEY
+      - STAGING_DOCS_ECR_SECRET
+      - PRODUCTION_DOCS_ECR_KEY
+      - PRODUCTION_DOCS_ECR_SECRET
+    script: .cloudbuild/publish-image-ecr.sh 
+availableSecrets:
+  secretManager:
+  - versionName: projects/771512790633/secrets/ci_docs_ecr_staging_key/versions/1
+    env: STAGING_DOCS_ECR_KEY
+  - versionName: projects/771512790633/secrets/ci_docs_ecr_staging_secret/versions/1
+    env: STAGING_DOCS_ECR_SECRET
+  - versionName: projects/771512790633/secrets/ci_docs_ecr_production_key/versions/1
+    env: PRODUCTION_DOCS_ECR_KEY
+  - versionName: projects/771512790633/secrets/ci_docs_ecr_production_secret/versions/1
+    env: PRODUCTION_DOCS_ECR_SECRET
+    

--- a/.cloudbuild/publish-image-ecr.sh
+++ b/.cloudbuild/publish-image-ecr.sh
@@ -1,7 +1,7 @@
 #! /bin/env bash
 set -e
 
-STAGING_DOCKER_IMAGE=146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/docs:latest
+STAGING_DOCKER_IMAGE=146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/docs:$COMMIT_SHA
 PRODUCTION_DOCKER_IMAGE=public.ecr.aws/gravitational/docs:latest
 
 ## Install aws
@@ -19,12 +19,12 @@ export AWS_ACCESS_SECRET_KEY=$STAGING_DOCS_ECR_SECRET
 aws ecr get-login-password --region us-west-2 | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
 
 ## Push Staging Image
-docker push $PRODUCTION_DOCKER_IMAGE
+docker push $STAGING_DOCKER_IMAGE
 
 ## Authenticate to Production AWS Registry
+docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
 export AWS_ACCESS_KEY_ID=$PRODUCTION_DOCS_ECR_KEY
 export AWS_ACCESS_SECRET_KEY=$PRODUCTION_DOCS_ECR_SECRET
-
 aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin public.ecr.aws
 
 ## Push Production Image

--- a/.cloudbuild/publish-image-ecr.sh
+++ b/.cloudbuild/publish-image-ecr.sh
@@ -1,0 +1,32 @@
+#! /bin/env bash
+set -e
+
+STAGING_DOCKER_IMAGE=146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/docs:latest
+PRODUCTION_DOCKER_IMAGE=public.ecr.aws/gravitational/docs:latest
+
+## Install aws
+apt install awscli
+
+## Build Docker Image
+echo Building $STAGING_DOCKER_IMAGE
+
+DOCKER_BUILDKIT=1 docker build -t $STAGING_DOCKER_IMAGE .
+
+## Authenticate to Staging AWS Registry
+export AWS_ACCESS_KEY_ID=$STAGING_DOCS_ECR_KEY
+export AWS_ACCESS_SECRET_KEY=$STAGING_DOCS_ECR_SECRET
+
+aws ecr get-login-password --region us-west-2 | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
+
+## Push Staging Image
+docker push $PRODUCTION_DOCKER_IMAGE
+
+## Authenticate to Production AWS Registry
+export AWS_ACCESS_KEY_ID=$PRODUCTION_DOCS_ECR_KEY
+export AWS_ACCESS_SECRET_KEY=$PRODUCTION_DOCS_ECR_SECRET
+
+aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin public.ecr.aws
+
+## Push Production Image
+docker tag $STAGING_DOCKER_IMAGE $PRODUCTION_DOCKER_IMAGE
+docker push $PRODUCTION_DOCKER_IMAGE


### PR DESCRIPTION
This PR is apart of [RFD 73](https://github.com/gravitational/teleport/blob/81e8eac68c773ba52f8a3822df0654c2d82d7e70/rfd/0073-public-image-registry.md) which migrates docker images from Quay.io to Amazon ECR. 

This PR adds an additional cloud-build steps that push the image to amazon ECR.

This PR does not update any existing docs docker build infrastructure in order to not disrupt any current builds. 

## Related
* https://github.com/gravitational/ops/pull/386