### PR TITLE
Check config.json URLs for corresponding files

### DIFF
--- a/server/config-docs.test.ts
+++ b/server/config-docs.test.ts
@@ -1,0 +1,45 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import { normalizeDocsUrl } from "./config-docs";
+import { randomUUID } from "crypto";
+import { resolve } from "path";
+import { opendirSync } from "fs";
+
+const Suite = suite("server/config-docs");
+
+Suite("Ensures that URLs correspond to docs pages", () => {
+  // There's currently no way to pass an arbitrary directory path to
+  // normalizeDocsUrl, which assumes that docs pages are in
+  // "content/<version>/docs/pages. As a result, we define a fake docs page
+  // path by generating a UUID.
+  const fakeURL = "/" + randomUUID() + "/";
+
+  // Use the first directory we find in the content directory to get a
+  // version. We don't care which version it is since we'll be creating a fake
+  // file there anyway, but we do need a real config.json file to load.
+  const contentPath = resolve("content");
+  const contentDir = opendirSync(contentPath);
+  const vers = contentDir.readSync().name;
+
+  // Make sure there aren't any unexpected files in the user's content directory
+  if (vers.match(/^[0-9]+\.[0-9]+$/) == null) {
+    throw Error("unexpected subdirectory in the content directory: " + vers);
+  }
+
+  assert.throws(
+    () => {
+      normalizeDocsUrl(vers, fakeURL);
+    },
+    (err) => {
+      return err.message.includes(fakeURL);
+    }
+  );
+
+  // This should not throw an error, since there's always going to be a root
+  // path.
+  normalizeDocsUrl(vers, "/");
+
+  contentDir.closeSync();
+});
+
+Suite.run();

--- a/server/config-docs.test.ts
+++ b/server/config-docs.test.ts
@@ -35,9 +35,11 @@ Suite("Ensures that URLs correspond to docs pages", () => {
     }
   );
 
-  // This should not throw an error, since there's always going to be a root
+  // This should not throw an exception, since there's always going to be a root
   // path.
   normalizeDocsUrl(vers, "/");
+  // Disabling URL checking should not throw an exception
+  normalizeDocsUrl(vers, fakeURL, false);
 
   contentDir.closeSync();
 });

--- a/server/fixtures/fake-content/about/introduction.mdx
+++ b/server/fixtures/fake-content/about/introduction.mdx
@@ -1,0 +1,4 @@
+---
+title: About
+description: This is the "about" section
+---

--- a/server/fixtures/fake-content/about/projects/project1.mdx
+++ b/server/fixtures/fake-content/about/projects/project1.mdx
@@ -1,0 +1,4 @@
+---
+title: Project 1
+description: "Here's information about Project 1"
+---

--- a/server/fixtures/fake-content/about/projects/project2.mdx
+++ b/server/fixtures/fake-content/about/projects/project2.mdx
@@ -1,0 +1,4 @@
+---
+title: Project 2
+description: "Here's information about Project 2"
+---

--- a/server/fixtures/fake-content/about/team.mdx
+++ b/server/fixtures/fake-content/about/team.mdx
@@ -1,0 +1,4 @@
+---
+title: Team
+description: Information about the team
+---

--- a/server/fixtures/fake-content/contact/offices.mdx
+++ b/server/fixtures/fake-content/contact/offices.mdx
@@ -1,0 +1,4 @@
+---
+title: Offices
+description: Information about our offices
+---

--- a/server/fixtures/fake-content/index.mdx
+++ b/server/fixtures/fake-content/index.mdx
@@ -1,0 +1,4 @@
+---
+title: Home Page
+description: There's no place like it.
+---


### PR DESCRIPTION
Fixes #101

When loading the `docs/config.json` file for each version of the docs
site, we have some logic in `normalizeDocsUrl` that validates URLs
(i.e., checks if the URL has a trailing slash) and adds a
version-specific path segment to the URL path.

This changes `normalizeDocsUrl` to also check if a file exists at the
given URL path. This way, docs site builds fail if (a) a navigation
entry exists for a nonexistent docs page; or (b) a redirect points to a
nonexistent docs page.

Unfortunately, throughout the code that handles `config.json`, there is
logic that assumes the file lives in
`content/<version>/docs/config.json`. To test this change on a test data
directory, rather than an actual docs site directory, we would need to
refactor a lot of `server/config-docs.ts` and the code that imports from
it.

As a result, in order to test only `normalizeDocsUrl`, I had to make it
an exported function. I also had to make assumptions in the tests that
there would be a `content` directory populated with per-version
subdirectories.