### PR TITLE
Make the config.json error message more explicit

### DIFF
--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -330,8 +330,10 @@ export const loadConfig = (version: string) => {
 
   if (badSlugs.length > 0) {
     throw new Error(
-      "The following navigation slugs or redirect destinations do not" +
-        " correspond to an actual MDX file:\n\t- " +
+      "Error parsing docs config file " +
+        join("content", version, "docs", "config.json") +
+        ": The following navigation slugs or redirect destinations do not " +
+        "correspond to actual MDX files:\n\t- " +
         badSlugs.join("\n\t- ")
     );
   }


### PR DESCRIPTION
We recently edited the docs engine to check the config.json for each
docs version to ensure that navigation entries and redirects do not
point to nonexistent pages. However, the error message was a bit
cryptic, causing some confusion about what was causing the error.

This change edits the error message to clarify that it has to do with
the config.json file for a specific version of the docs.