### PR TITLE
add --init to submodule script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "git-update": "git submodule update --remote",
+    "git-update": "git submodule update --init --remote",
     "build-node": "rm -rf .build && tsc --build tsconfig.node.json && tsc-esm-fix --target='.build' --ext='.mjs'",
     "add-symlinks": "node ./scripts/add-symlinks.mjs",
     "generate-sitemap": "node ./scripts/generate-sitemap.mjs",


### PR DESCRIPTION
This PR unblocks https://github.com/gravitational/teleport/pull/15851, wherein we discussed replacing the `git submodule` commands in the contributing page with a call to the `yarn git-update` script.

By adding `--init` the script call works on first use, and doesn't change behavior on subsequent use.