### PR TITLE
Fix bug with link parsing

### DIFF
--- a/components/Link/hooks.ts
+++ b/components/Link/hooks.ts
@@ -42,7 +42,7 @@ export const useNormalizedHref = (href: string) => {
   // This needs to be added because all strings of "/docs/" are being stripped down to
   // "/" in noBaseHref. This is called below useContext because of the rule of hooks
   // in which hooks are not able to be called conditionally
-  if (href.startsWith(`${basePath}/`)) {
+  if (href === `${basePath}/`) {
     return href;
   }
 


### PR DESCRIPTION
Preview [here](https://docs-git-sandy-fix-docs-gravitational.vercel.app/docs/)

PR https://github.com/gravitational/docs/pull/148 fixed parsing of `/docs` from `href`s, but did not account for some edge cases. This PR fixes that by making the conditional more specific.

<img width="727" alt="Screen Shot 2022-09-13 at 4 32 28 PM" src="https://user-images.githubusercontent.com/60662264/190027472-e6e14041-a288-45e3-9060-3181706f3705.png">
