### PR TITLE
Import Icon component, allow inline use

### DIFF
--- a/components/Icon/Icon.module.css
+++ b/components/Icon/Icon.module.css
@@ -27,3 +27,33 @@
     --size: 40px;
   }
 }
+
+.inline {
+  display: inline;
+  width: var(--size);
+  height: var(--size);
+
+  &.xxs {
+    --size: 10px;
+  }
+
+  &.xs {
+    --size: 12px;
+  }
+
+  &.sm {
+    --size: 16px;
+  }
+
+  &.md {
+    --size: 24px;
+  }
+
+  &.lg {
+    --size: 32px;
+  }
+
+  &.xl {
+    --size: 40px;
+  }
+}

--- a/components/Icon/Icon.module.css
+++ b/components/Icon/Icon.module.css
@@ -30,30 +30,5 @@
 
 .inline {
   display: inline;
-  width: var(--size);
-  height: var(--size);
-
-  &.xxs {
-    --size: 10px;
-  }
-
-  &.xs {
-    --size: 12px;
-  }
-
-  &.sm {
-    --size: 16px;
-  }
-
-  &.md {
-    --size: 24px;
-  }
-
-  &.lg {
-    --size: 32px;
-  }
-
-  &.xl {
-    --size: 40px;
-  }
+  margin-left: 4px;
 }

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -7,16 +7,25 @@ export interface IconProps {
   name: IconName;
   size?: "xxs" | "xs" | "sm" | "md" | "lg" | "xl";
   className?: string;
+  inline?: boolean;
 }
 
-const Icon = ({ name, size = "md", className }: IconProps) => {
+const Icon = ({ name, size = "md", className, inline = false }: IconProps) => {
   const IconSVG = icons[name];
 
   if (!IconSVG) {
     return <span className={cn(styles.wrapper, styles[size], className)} />;
   }
 
-  return <IconSVG className={cn(styles.wrapper, styles[size], className)} />;
+  return (
+    <IconSVG
+      className={cn(
+        inline ? styles.inline : styles.wrapper,
+        styles[size],
+        className
+      )}
+    />
+  );
 };
 
 export default Icon;

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -19,11 +19,9 @@ const Icon = ({ name, size = "md", className, inline = false }: IconProps) => {
 
   return (
     <IconSVG
-      className={cn(
-        inline ? styles.inline : styles.wrapper,
-        styles[size],
-        className
-      )}
+      className={cn(styles.wrapper, styles[size], className, {
+        [styles.inline]: inline,
+      })}
     />
   );
 };

--- a/layouts/DocsPage/components.tsx
+++ b/layouts/DocsPage/components.tsx
@@ -1,5 +1,6 @@
 import Admonition from "components/Admonition";
 import Command, { CommandLine, CommandComment } from "components/Command";
+import Icon from "components/Icon";
 import InlineCode from "components/InlineCode";
 import Notice from "components/Notice";
 import ScopedBlock from "components/ScopedBlock";
@@ -65,6 +66,7 @@ export const components = {
   Command,
   CommandLine,
   CommandComment,
+  Icon,
   InlineCode,
   ScopedBlock,
   Tabs,


### PR DESCRIPTION
- Adds the `Icon` component to the docs layout
- Adds to the Icon component an `inline` boolean that, when set, allows Icons to be used inline in docs copy. I will link a PR to the docs shortly that will demonstrate.