### PR TITLE
Adjust passthrough as optional for DropdownMenuItem

### DIFF
--- a/components/DropdownMenu/DropdownMenuItem.tsx
+++ b/components/DropdownMenu/DropdownMenuItem.tsx
@@ -9,6 +9,7 @@ export interface MenuItemProps {
   href: string;
   icon?: IconName;
   image?: string;
+  skipNormalize?: boolean;
 }
 
 const DropdownMenuItem = ({
@@ -17,9 +18,15 @@ const DropdownMenuItem = ({
   title,
   description,
   href,
+  skipNormalize,
 }: MenuItemProps) => {
   return (
-    <Link href={href} passthrough className={styles.wrapper}>
+    <Link
+      href={href}
+      passthrough
+      className={styles.wrapper}
+      skipNormalize={skipNormalize}
+    >
       {image && (
         <div className={styles["image-wrapper"]}>
           <NextImage

--- a/components/DropdownMenu/DropdownMenuItem.tsx
+++ b/components/DropdownMenu/DropdownMenuItem.tsx
@@ -9,7 +9,7 @@ export interface MenuItemProps {
   href: string;
   icon?: IconName;
   image?: string;
-  skipNormalize?: boolean;
+  passthrough?: boolean;
 }
 
 const DropdownMenuItem = ({
@@ -18,15 +18,10 @@ const DropdownMenuItem = ({
   title,
   description,
   href,
-  skipNormalize,
+  passthrough = true,
 }: MenuItemProps) => {
   return (
-    <Link
-      href={href}
-      passthrough
-      className={styles.wrapper}
-      skipNormalize={skipNormalize}
-    >
+    <Link href={href} passthrough={passthrough} className={styles.wrapper}>
       {image && (
         <div className={styles["image-wrapper"]}>
           <NextImage

--- a/components/DropdownMenu/DropdownMenuItem.tsx
+++ b/components/DropdownMenu/DropdownMenuItem.tsx
@@ -18,7 +18,7 @@ const DropdownMenuItem = ({
   title,
   description,
   href,
-  passthrough = true,
+  passthrough = true, // If no value is sent, default to true
 }: MenuItemProps) => {
   return (
     <Link href={href} passthrough={passthrough} className={styles.wrapper}>

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -11,7 +11,6 @@ export interface LinkProps extends Omit<NextLinkProps, "href"> {
   href: string;
   onClick?: () => void;
   children: React.ReactNode;
-  skipNormalize?: boolean;
 }
 
 const Link = ({
@@ -26,7 +25,6 @@ const Link = ({
   prefetch,
   locale,
   scheme,
-  skipNormalize,
   ...linkProps
 }: LinkProps) => {
   const normalizedHref = useNormalizedHref(href);

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -30,17 +30,7 @@ const Link = ({
   ...linkProps
 }: LinkProps) => {
   const normalizedHref = useNormalizedHref(href);
-  if (skipNormalize) {
-    return (
-      <a
-        href={href}
-        {...linkProps}
-        className={cn(styles.wrapper, styles[scheme], className)}
-      >
-        {children}
-      </a>
-    );
-  } else if (
+  if (
     passthrough ||
     isHash(normalizedHref) ||
     isLocalAssetFile(normalizedHref)
@@ -54,7 +44,9 @@ const Link = ({
         {children}
       </a>
     );
-  } else if (isExternalLink(normalizedHref)) {
+  }
+
+  if (isExternalLink(normalizedHref)) {
     return (
       <a
         href={normalizedHref}
@@ -68,6 +60,7 @@ const Link = ({
     );
   }
 
+  // At this point, we return Link from the next/link package
   const nextProps: NextLinkProps = {
     href: normalizedHref,
     as,

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -11,6 +11,7 @@ export interface LinkProps extends Omit<NextLinkProps, "href"> {
   href: string;
   onClick?: () => void;
   children: React.ReactNode;
+  skipNormalize?: boolean;
 }
 
 const Link = ({
@@ -25,11 +26,21 @@ const Link = ({
   prefetch,
   locale,
   scheme,
+  skipNormalize,
   ...linkProps
 }: LinkProps) => {
   const normalizedHref = useNormalizedHref(href);
-
-  if (
+  if (skipNormalize) {
+    return (
+      <a
+        href={href}
+        {...linkProps}
+        className={cn(styles.wrapper, styles[scheme], className)}
+      >
+        {children}
+      </a>
+    );
+  } else if (
     passthrough ||
     isHash(normalizedHref) ||
     isLocalAssetFile(normalizedHref)

--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -142,9 +142,9 @@ const menu: MenuCategoryProps[] = [
       },
       {
         icon: "book",
-        title: "User Guides",
-        description: "Documentation for end users",
-        href: "/docs/user-guides/",
+        title: "Teleport Clients",
+        description: "Learn how to conenct to Teleport-protected services",
+        href: "/docs/connect-your-client/introduction/",
         passthrough: false,
       },
       {

--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -145,7 +145,7 @@ const menu: MenuCategoryProps[] = [
         title: "User Guides",
         description: "Documentation for end users",
         href: "/docs/user-guides/",
-        skipNormalize: true,
+        passthrough: false,
       },
       {
         icon: "gamepad",

--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -145,6 +145,7 @@ const menu: MenuCategoryProps[] = [
         title: "User Guides",
         description: "Documentation for end users",
         href: "/docs/user-guides/",
+        skipNormalize: true,
       },
       {
         icon: "gamepad",

--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -141,6 +141,12 @@ const menu: MenuCategoryProps[] = [
         href: "/docs/",
       },
       {
+        icon: "book",
+        title: "User Guides",
+        description: "Documentation for end users",
+        href: "/docs/user-guides/",
+      },
+      {
         icon: "gamepad",
         title: "How It Works",
         description: "Learn the fundamentals of how Teleport works",

--- a/tests/data/navbar-data.ts
+++ b/tests/data/navbar-data.ts
@@ -124,6 +124,10 @@ export const navigationData: NavbarData = [
           href: "/docs/",
         },
         {
+          title: "Teleport Clients",
+          href: "/docs/connect-your-client/introduction/",
+        },
+        {
           title: "How It Works",
           href: "/how-it-works/",
           isExternal: true,


### PR DESCRIPTION
- Adds a header link for the end users guide (this PR depends on https://github.com/gravitational/teleport/pull/18055)
- ~Since the new header link includes `/docs` and our current Link component normalizes links based on the assumption that we would never link to anything but a single-depth subdir of the site, I've created a `skipNormalize` boolean to bypass the normalization function applied to hrefs.~
- Adjusts the passthrough variable such that, instead of always being true it is true by default but can be overridden, so that links in the dropdown menu can use the NextLink component.