### PR TITLE
Allow more paths in partial link resolution

### DIFF
--- a/server/fixtures/includes/database-access/attach-iam-policies.mdx
+++ b/server/fixtures/includes/database-access/attach-iam-policies.mdx
@@ -1,0 +1,11 @@
+Attach the policy and permission boundary you created earlier to the IAM
+identity your Teleport Database Service will be using.
+
+For example, if the Database Service runs as an IAM user, go to the page of the IAM user
+in the AWS Management Console, attach the created policy in the "Permissions
+policies" section, and set the created boundary policy in the "Permissions
+boundary" section.
+
+<Figure>
+![IAM user](../../../img/database-access/iam@2x.png)
+</Figure>

--- a/server/fixtures/includes/include-relative-link.mdx
+++ b/server/fixtures/includes/include-relative-link.mdx
@@ -1,0 +1,6 @@
+
+Check out our [instructions](../installation.mdx).
+
+Here is an image showing a successful installation:
+
+[Successful installation](../installation.png)

--- a/server/fixtures/includes/includes-relative-link-def.mdx
+++ b/server/fixtures/includes/includes-relative-link-def.mdx
@@ -1,0 +1,3 @@
+This partial has a relative link [definition].
+
+[definition]: ../../installation.mdx


### PR DESCRIPTION
Fixes #167

`handlePartialLink` currently hardcodes `docs/pages` as the location of
all docs pages, and uses this file path segment to construct the absolute
path of the MDX file that includes a partial.

This change adds the root directory of all partials as a parameter of
`handlePartialLink` and uses that instead. Since this root directory is
configurable outside `remark-includes`, this change lets us add unit
tests for `handlePartialLink`.

This change also handles relative path resolution for image and link
definition URLs. The current version of `handlePartialLink` only handles
links paths. As a result, this renames `handlePartialLink` to
`handleURLPath`.