### PR TITLE
Remove the introductory text from the VarList

### DIFF
--- a/components/Variables/VarList.tsx
+++ b/components/Variables/VarList.tsx
@@ -34,10 +34,6 @@ export const VarList = () => {
 
   return (
     <section>
-      <p className={styles.text}>
-        You can fill in the variables for more comfortable use of the
-        documentation
-      </p>
       {!!globalFieldsList.length && (
         <>
           <h2 className={styles.title}>Documentation-wide variables</h2>


### PR DESCRIPTION
This allows us to be more flexible with how we include a VarList component within a docs page, since we can adjust the introductory text to accommodate surrounding paragraphs etc.