### PR TITLE
Ignore `docs/pages/includes` files when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "yarn base:eslint --fix && yarn base:prettier --write -l",
     "lint-check": "yarn base:eslint && yarn base:prettier --check",
     "typecheck": "tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile node_modules/.cache/tsc/tsbuildinfo --project .",
-    "markdown-lint": "remark 'content/**/docs/pages/**/*.mdx' --frail",
+    "markdown-lint": "remark 'content/**/docs/pages/**/*.mdx' --frail --ignore-pattern 'content/*/docs/pages/includes/*' --silently-ignore",
     "markdown-lint-external-links": "WITH_EXTERNAL_LINKS=true yarn markdown-lint",
     "markdown-fix": "FIX=true yarn markdown-lint -o"
   },


### PR DESCRIPTION
Closes #191

The `markdown-lint` script includes all files in `docs/pages/includes`. The script also processes partial inclusion expressions within docs pages, then lints those pages. This means that partials are linted at least twice: once on their own and for every time they are included in a docs page.

The first lint pass for each partial usually works as expected. However, there is an issue if a partial includes a default parameter value (#171), like this:

```
{{ var="default value" }}

Here is a variable with a {{ var }}.
```

When a page includes this partial, the docs engine removes the first line before inserting the resolved text. As a result, partials with default parameters render as expected and pass the linter within their including pages.

But when we run the `markdown-lint` script, and the linter checks the partial on its own, the first line remains in the partial. This causes the linter to return an error.

This change edits the `markdown-lint` script to ignore files within `docs/pages/includes`. This will allow us to use partials with default parameter values without them breaking CI.