### PR TITLE
Ignore all includes directories when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "yarn base:eslint --fix && yarn base:prettier --write -l",
     "lint-check": "yarn base:eslint && yarn base:prettier --check",
     "typecheck": "tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile node_modules/.cache/tsc/tsbuildinfo --project .",
-    "markdown-lint": "remark 'content/**/docs/pages/**/*.mdx' --frail --ignore-pattern 'content/*/docs/pages/includes/*' --silently-ignore",
+    "markdown-lint": "remark 'content/**/docs/pages/**/*.mdx' --frail --ignore-pattern '**/includes/**' --silently-ignore",
     "markdown-lint-external-links": "WITH_EXTERNAL_LINKS=true yarn markdown-lint",
     "markdown-fix": "FIX=true yarn markdown-lint -o"
   },


### PR DESCRIPTION
The intention in #192 was to ignore directories containing partials when linting, since (a) these partials would be included within docs pages when linting anyway, and (b) the linter returns errors when encountering default parameter assignments within partials.

The change in #192 ignored includes in `content/*/docs/pages/includes/*`.

However, in the `gravitational/teleport` CI container, docs content is mounted to `content/`, without a version directory. This means that default parameter assignments in `gravitational/teleport` partials still fail the linter, since the partial URL would be something like `content/docs/pages/includes/add-role-to-user.mdx`.

This change makes the pattern for ignoring partials more general so it matches any file path with an `/includes/` segment.