### PR TITLE
Remove "What is SSH" from navigation

### DIFF
--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -203,13 +203,6 @@ const menu: MenuCategoryProps[] = [
         description: "View our upcoming events",
         href: "/about/events/",
       },
-      {
-        icon: "code2",
-        title: "What is SSH?",
-        description:
-          "Learn the basics of SSH and how it's used to Access Infrastructure",
-        href: "/ssh/",
-      },
     ],
   },
   {

--- a/tests/data/navbar-data.ts
+++ b/tests/data/navbar-data.ts
@@ -181,11 +181,6 @@ export const navigationData: NavbarData = [
           href: "/about/events/",
           isExternal: true,
         },
-        {
-          title: "What is SSH?",
-          href: "/ssh/",
-          isExternal: true,
-        },
       ],
     },
   },


### PR DESCRIPTION
Removed "What is SSH" link from header navigation as per this task: https://app.asana.com/0/1202613463734613/1203682021891036/f