### PR TITLE
Update gitmodules to point to branch/v12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,4 @@
 [submodule "content/12.x"]
 	path = content/12.x
 	url = https://github.com/gravitational/teleport
-	branch = master
+	branch = branch/v12


### PR DESCRIPTION
At the moment, `content/12.x` points to `master` which pulls in `web` and causes type checking issues

This updates the submodule to point to `branch/v12`