### PR TITLE
Add workflow for building and pushing docs image to ghcr

### DIFF
--- a/.github/workflows/buildbox.yaml
+++ b/.github/workflows/buildbox.yaml
@@ -1,0 +1,42 @@
+name: Build Docs Image
+run-name: Build Docs Image
+on:
+  push:
+    paths:
+      - Dockerfile
+      - Makefile
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  DOCKER_IMAGE: ghcr.io/gravitational/docs:latest
+
+jobs:
+  buildbox:
+    name: Build Docs Image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Docs
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build buildbox image
+        run: make docker-image
+
+      - name: Docker push the latest built image
+        run: make docker-push

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMAGE=quay.io/gravitational/next:main
+DOCKER_IMAGE ?= quay.io/gravitational/next:main
 
 # Commands for building the Docker image.
 .PHONY: docker-pull


### PR DESCRIPTION
Currently our CI checks in Teleport repo pull docs image from ECR for the linter check:

https://github.com/gravitational/teleport/blob/34f102bdeb379570fb0f6432f11716c15ed02f82/.github/workflows/doc-tests.yaml#L20

This results in ECR throttling and the docs check failing, for example:

https://github.com/gravitational/teleport/actions/runs/4025957454/jobs/6919840933

Similar to how we do it with Teleport's own buildboxes, this PR adds a workflow that pushes the docs image to ghcr instead of (or rather, in addition to) ECR which our CI checks will get it from:

https://github.com/gravitational/teleport/blob/34f102bdeb379570fb0f6432f11716c15ed02f82/.github/workflows/build-ci-buildbox-images.yaml