### PR TITLE
Specify the remark config path in markdown-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "yarn base:eslint --fix && yarn base:prettier --write -l",
     "lint-check": "yarn base:eslint && yarn base:prettier --check",
     "typecheck": "tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile node_modules/.cache/tsc/tsbuildinfo --project .",
-    "markdown-lint": "remark 'content/**/docs/pages/**/*.mdx' --frail --ignore-pattern '**/includes/**' --silently-ignore",
+    "markdown-lint": "remark --rc-path .remarkrc.mjs 'content/**/docs/pages/**/*.mdx' --frail --ignore-pattern '**/includes/**' --silently-ignore",
     "markdown-lint-external-links": "WITH_EXTERNAL_LINKS=true yarn markdown-lint",
     "markdown-fix": "FIX=true yarn markdown-lint -o"
   },


### PR DESCRIPTION
Closes #231

The `markdown-lint` command defined in `package.json` does not define a config file, meaning that `remark` will search for a config file automatically.

After we merged the `gravitational/webapps` code with `gravitational/teleport`, `gravitational/teleport` started to include multiple `package.json` files. This interferes with `remark`'s config search, causing `remark` to ignore our plugin config. As a result, the linter passes when it should be returning errors.

By specifying a `remark` config file explicitly in `markdown-lint`, we can ensure that `remark` uses the correct config regardless of the content of the versioned `content` submodules. Since `gravitational/docs` is decoupled from its submodules, we should not expect a given version of a submodule to necessarily play nicely with the tools we run in the parent module.