### PR TITLE
remove v9 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "content/9.x"]
-	path = content/9.x
-	url = https://github.com/gravitational/teleport
-	branch = branch/v9
 [submodule "content/10.x"]
 	path = content/10.x
 	url = https://github.com/gravitational/teleport


### PR DESCRIPTION
Since we don't display version 9 anymore, removing it changes nothing in the render, and might improve our build success rates by reducing the number of OOMs.