### PR TITLE
Lint incorrect messaging in the docs

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,3 +1,4 @@
+import { resolve } from "path";
 import remarkVariables from "./.build/server/remark-variables.mjs";
 import remarkIncludes from "./.build/server/remark-includes.mjs";
 import remarkCodeSnippet from "./.build/server/remark-code-snippet.mjs";
@@ -73,9 +74,7 @@ const configLint = {
     [remarkLintFrontmatter, ["error"]],
     [
       remarkLintMessaging,
-      (vfile) => {
-        return loadMessagingConfig(getVersion(vfile.path));
-      },
+      loadMessagingConfig(resolve("messaging-config.json")),
     ],
   ],
 };

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -7,7 +7,11 @@ import {
   getVersion,
   getVersionRootPath,
 } from "./.build/server/docs-helpers.mjs";
-import { loadConfig } from "./.build/server/config-docs.mjs";
+import {
+  loadConfig,
+  loadMessagingConfig,
+} from "./.build/server/config-docs.mjs";
+import { remarkLintMessaging } from "./.build/server/remark-lint-messaging.mjs";
 
 const configFix = {
   settings: {
@@ -61,12 +65,18 @@ const configLint = {
       },
     ],
     // validate-links must be run after remarkVariables since some links
-    // include variables in their references, e.g., 
+    // include variables in their references, e.g.,
     // [CM-08 Information System Component Inventory]((=fedramp.control_url=)CM-8)
     ["validate-links", { repository: false }],
     [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
     [remarkLintDetails, ["error"]],
     [remarkLintFrontmatter, ["error"]],
+    [
+      remarkLintMessaging,
+      (vfile) => {
+        return loadMessagingConfig(getVersion(vfile.path));
+      },
+    ],
   ],
 };
 

--- a/messaging-config.json
+++ b/messaging-config.json
@@ -12,6 +12,7 @@
   {
     "incorrect": "(Database|Server|Application|Desktop|Kubernetes) Access\\W",
     "correct": "write about adding a resource or protocol, instead of using \"<Resource> Access\" as a proper noun",
-    "explanation": "Avoid the suggestion that Teleport includes multiple products, rather than a unified access platform"
+    "explanation": "Avoid the suggestion that Teleport includes multiple products, rather than a unified access platform",
+    "where": ["description", "headers", "comments", "body"]
   }
 ]

--- a/messaging-config.json
+++ b/messaging-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "incorrect": "\\W(machine id|(database|app(lication)?|desktop|kubernetes|ssh|discovery) service)\\W",
+    "correct": "capitalize the names of Teleport services",
+    "explanation": "We want to ensure that product names are consistent across the docs"
+  },
+  {
+    "incorrect": "\\Wauth and proxy( services?)?\\W",
+    "correct": "use \"Auth and Proxy Services\"",
+    "explanation": "We want to ensure that product names are consistent across the docs"
+  },
+  {
+    "incorrect": "(Database|Server|Application|Desktop|Kubernetes) Access\\W",
+    "correct": "write about adding a resource or protocol, instead of using \"<Resource> Access\" as a proper noun",
+    "explanation": "Avoid the suggestion that Teleport includes multiple products, rather than a unified access platform"
+  }
+]

--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -145,6 +145,13 @@ const messagingConfigValidator = ajv.compile({
       explanation: {
         type: "string",
       },
+      where: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["title", "description", "comments", "body", "headers"],
+        },
+      },
     },
   },
 });

--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -22,19 +22,20 @@ export interface Config {
   redirects?: Redirect[];
 }
 
-const getConfigPath = (version: string, filename: string) =>
-  resolve("content", version, "docs", filename);
+const getConfigPath = (version: string) =>
+  resolve("content", version, "docs/config.json");
 
 /*
  * Try to load config file and throw error if it does not exist.
  */
-export const load = <T>(version: string, filename: string): T => {
-  const path = getConfigPath(version, filename);
+
+export const load = (version: string) => {
+  const path = getConfigPath(version);
 
   if (existsSync(path)) {
     const content = readFileSync(path, "utf-8");
 
-    return JSON.parse(content) as T;
+    return JSON.parse(content) as Config;
   } else {
     throw Error(`File ${path} does not exist.`);
   }
@@ -166,7 +167,7 @@ export const normalizeDocsUrl = (version: string, url: string) => {
   }
 
   const path = splitPath(url).path;
-  const configPath = getConfigPath(version, "config.json");
+  const configPath = getConfigPath(version);
 
   if (!path.endsWith("/")) {
     throw Error(`File ${configPath} misses trailing slash in '${url}' path.`);
@@ -326,7 +327,7 @@ export const normalize = (config: Config, version: string): Config => {
 /* Load, validate and normalize config. */
 
 export const loadConfig = (version: string) => {
-  const config = load<Config>(version, "config.json");
+  const config = load(version);
 
   const badSlugs = checkURLsForCorrespondingFiles(
     join("content", version, "docs", "pages"),
@@ -349,12 +350,14 @@ export const loadConfig = (version: string) => {
   return normalize(config, version);
 };
 
-export const loadMessagingConfig = (version: string) => {
-  const config = load<RemarkLintMessagingOptions>(
-    version,
-    "messaging-config.json"
-  );
-
+export const loadMessagingConfig = (
+  path: string
+): RemarkLintMessagingOptions => {
+  if (!existsSync(path)) {
+    throw Error(`File ${path} does not exist.`);
+  }
+  const content = readFileSync(path, "utf-8");
+  const config = JSON.parse(content) as RemarkLintMessagingOptions;
   validateConfig<RemarkLintMessagingOptions>(messagingConfigValidator, config);
 
   return config;

--- a/server/remark-lint-messaging.ts
+++ b/server/remark-lint-messaging.ts
@@ -1,0 +1,131 @@
+import { lintRule } from "unified-lint-rule";
+import { visit } from "unist-util-visit";
+import type { VFile } from "vfile";
+import type { Position, Node, Parent } from "unist";
+import type { Code, Literal } from "mdast";
+import find from "unist-util-find";
+import yaml from "js-yaml";
+
+interface RemarkLintMessagingRule {
+  correct: string;
+  incorrect: string;
+  explanation: string;
+}
+
+interface Frontmatter {
+  title?: string;
+  description?: string;
+}
+
+export type RemarkLintMessagingOptions = RemarkLintMessagingRule[];
+
+const allowedNodeTypes = {
+  paragraph: true,
+  heading: true,
+};
+
+function checkMessaging(
+  conf: RemarkLintMessagingOptions,
+  file: VFile,
+  pos: Position,
+  text: string
+) {
+  if (!Array.isArray(conf) || conf.length === 0) {
+    throw new Error(
+      "Cannot check messaging with an empty messaging configuration"
+    );
+  }
+  conf.forEach((rule) => {
+    const re = new RegExp(rule.incorrect);
+    // Empty text, so skip
+    if (text === undefined) {
+      return;
+    }
+    const badText = text.match(re);
+    if (text.match(re)) {
+      file.message(
+        `Incorrect messaging: "${badText[0]}". ${rule.explanation}. You should ${rule.correct}. ` +
+          'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+        pos
+      );
+    }
+  });
+}
+
+function isTextOrCodeNode(node: Node) {
+  return node.type === "text" || node.type === "code";
+}
+
+// getCommentText takes the text node value of a code fence, i.e., all comments
+// and lines of comment, and returns the result of concatenating all comments,
+// removing comment syntax. Supports:
+// - /* */
+// - //
+// - #
+function getCommentText(value: string): string {
+  // Matches the start of a comment.
+  const commentStart = new RegExp("^(/\\* | \\* |// |# )");
+  const lines = value.split("\n");
+  return lines.reduce((result, current) => {
+    const match = current.match(commentStart);
+    if (match !== null) {
+      let txt = current.slice(match[0].length, current.length);
+      // ensure that we concatenate lines without combining words
+      if (current[current.length - 1] !== " ") {
+        txt += " ";
+      }
+      return result + txt;
+    }
+    return result;
+  }, "");
+}
+
+export const remarkLintMessaging = lintRule(
+  "remark-lint:messaging",
+  (
+    root: Parent,
+    file: VFile,
+    options:
+      | RemarkLintMessagingOptions
+      | ((vfile: VFile) => RemarkLintMessagingOptions)
+  ) => {
+    let config: RemarkLintMessagingOptions;
+
+    if (typeof options === "function") {
+      config = options(file);
+    } else {
+      config = options;
+    }
+
+    // This is a type of the node created by remark-frontmatter plugin in remark-lint
+    const node = find(root, (node: Node) => node.type === "yaml");
+
+    // If there's no frontmatter, we'll let other linting steps take care of
+    // it.
+    if (node !== undefined) {
+      const frontmatter = yaml.load(node.value as string) as Frontmatter;
+      const { title, description } = frontmatter;
+
+      checkMessaging(config, file, node.position, title);
+      checkMessaging(config, file, node.position, description);
+    }
+
+    visit(
+      root,
+      isTextOrCodeNode,
+      (node: Node, index: number, parent: Parent) => {
+        let val: string;
+
+        if (node.type == "code") {
+          val = getCommentText((node as Code).value);
+        }
+
+        if (parent.type == "paragraph" || parent.type == "heading") {
+          val = (node as Literal).value;
+        }
+
+        checkMessaging(config, file, node.position, val);
+      }
+    );
+  }
+);

--- a/uvu-tests/remark-messaging.test.ts
+++ b/uvu-tests/remark-messaging.test.ts
@@ -1,0 +1,182 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+
+import { VFile, VFileOptions } from "vfile";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { remark } from "remark";
+import remarkMdx from "remark-mdx";
+import {
+  remarkLintMessaging,
+  RemarkLintMessagingOptions,
+} from "../server/remark-lint-messaging";
+import remarkFrontmatter from "remark-frontmatter";
+
+const config: RemarkLintMessagingOptions = [
+  {
+    incorrect: "auth and proxy",
+    correct: 'use "Auth and Proxy Services" instead',
+    explanation: "You must capitalize product names",
+  },
+  {
+    incorrect: "Kubernetes Access",
+    correct: 'use "registering a Kubernetes cluster" instead',
+    explanation:
+      "Focus our messaging on a single product, rather than multiple",
+  },
+  {
+    incorrect: "machine id|auth service|database service",
+    correct: "capitalize the names of Teleport services",
+    explanation:
+      "See our Core Concepts page: https://goteleport.com/docs/core-concepts",
+  },
+];
+
+const transformer = (vfileOptions: VFileOptions): VFile => {
+  const file = new VFile(vfileOptions);
+
+  return remark()
+    .use(remarkMdx)
+    .use(remarkFrontmatter)
+    .use(remarkLintMessaging, config)
+    .processSync(file);
+};
+
+const getErrors = (result: VFile) => {
+  if (result.messages === undefined || result.messages.length == 0) {
+    return [];
+  }
+  return result.messages.map(({ message }) => message);
+};
+
+const Suite = suite("server/remark-messaging");
+
+Suite("Lint incorrect messaging in a paragraph", () => {
+  const value = `---
+title: "Getting Started"
+description: "How to get started"
+---
+
+This is a paragraph that talks about the auth and proxy services. You should
+install these services when getting started with Teleport.
+`;
+  const result = transformer({
+    value,
+    path: "/content/4.0/docs/pages/filename.mdx",
+  });
+
+  const expectedErrors = [
+    'Incorrect messaging: "auth and proxy". ' +
+      'You must capitalize product names. You should use "Auth and Proxy Services" instead. ' +
+      'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+  ];
+
+  assert.equal(getErrors(result), expectedErrors);
+});
+
+Suite("Lint incorrect messaging in a header", () => {
+  const value = `---
+title: "Access Kubernetes"
+description: "How to get started accessing Kubernetes."
+---
+
+In this guide, we will explain how to set up Teleport to access Kubernetes.
+
+## Step 1/1. Enable Kubernetes Access
+`;
+  const expectedErrors = [
+    'Incorrect messaging: "Kubernetes Access". Focus our messaging ' +
+      "on a single product, rather than multiple. You should use " +
+      '"registering a Kubernetes cluster" instead. ' +
+      'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+  ];
+
+  const result = transformer({
+    value,
+    path: "/content/4.0/docs/pages/filename.mdx",
+  });
+
+  assert.equal(getErrors(result), expectedErrors);
+});
+
+Suite("Lint incorrect messaging in a title", () => {
+  const value = `---
+title: "Get Started with Kubernetes Access"
+description: "How to get started accessing Kubernetes."
+---
+
+In this guide, we will explain how to set up Teleport to access Kubernetes.
+
+## Step 1/1. Enable the Kubernetes Service
+`;
+
+  const expectedErrors = [
+    'Incorrect messaging: "Kubernetes Access". Focus our messaging ' +
+      "on a single product, rather than multiple. You should use " +
+      '"registering a Kubernetes cluster" instead. Add "{/*lint ignore messaging*/}" ' +
+      "above this line to bypass the linter.",
+  ];
+
+  const result = transformer({
+    value,
+    path: "/content/4.0/docs/pages/filename.mdx",
+  });
+
+  assert.equal(getErrors(result), expectedErrors);
+});
+
+Suite("Lint incorrect messaging in a code comment", () => {
+  const value = `---
+title: "Getting Started"
+description: "How to get started"
+---
+
+Here is a YAML document:
+
+\`\`\`yaml
+# You can use this YAML to configure the auth and 
+# proxy.
+version: v3
+\`\`\`
+
+Here is a JS code fence:
+
+\`\`\`js
+/*
+ * You can use this YAML to configure Kubernetes Access
+*/
+function myfunc(string){
+\`\`\`
+
+Here is a Go code fence:
+
+\`\`\`go
+// Here is something for configuring machine 
+// id
+func myfunc(s string){
+\`\`\`
+
+`;
+  const result = transformer({
+    value,
+    path: "/content/4.0/docs/pages/filename.mdx",
+  });
+
+  const expectedErrors = [
+    'Incorrect messaging: "auth and proxy". You must capitalize product ' +
+      'names. You should use "Auth and Proxy Services" instead. ' +
+      'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+    'Incorrect messaging: "Kubernetes Access". Focus our messaging on a ' +
+      'single product, rather than multiple. You should use "registering a ' +
+      'Kubernetes cluster" instead. ' +
+      'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+    'Incorrect messaging: "machine id". See our Core Concepts page: ' +
+      "https://goteleport.com/docs/core-concepts. " +
+      "You should capitalize the names of Teleport services. " +
+      'Add "{/*lint ignore messaging*/}" above this line to bypass the linter.',
+  ];
+
+  assert.equal(getErrors(result), expectedErrors);
+});
+
+Suite.run();


### PR DESCRIPTION
Closes #154

One challenge for maintaining the docs is ensuring that we maintain consistent terms for different Teleport products and components.

This change adds a linter to prevent incorrect usage of terms and suggest alternatives with an explanation.

The configuration file, which must live in `docs/messaging-config.json` within a `gravitational/teleport` repo, looks like this, an array where each element is an object that specifies a rule:

```json
[
    {
    	"incorrect": "\\W(machine id|(database|app(lication)?|desktop|kubernetes|ssh|discovery) service)\\W",
    	"correct": "capitalize the names of Teleport services",
    	"explanation": "We want to ensure that product names are consistent across the docs"
    }
]
```

The `incorrect` field is a regular expression indicating a pattern to avoid. The config above would show a warning in the linter on, for example, `machine id`, `database service`, and `app service`. The `correct` and `explanation` fields are used to print error messages.

The intention is for docs authors to be able to adjust the linter config along with the docs content.