### PR TITLE
add keyword frontmatter to html head

### DIFF
--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -38,7 +38,7 @@ export interface HeadProps {
   titleSuffix?: string;
   url?: string;
   noIndex?: boolean;
-  keywords?: Array<String>;
+  keywords?: string[];
 }
 
 const Head = ({

--- a/components/Head/Head.tsx
+++ b/components/Head/Head.tsx
@@ -38,6 +38,7 @@ export interface HeadProps {
   titleSuffix?: string;
   url?: string;
   noIndex?: boolean;
+  keywords?: Array<String>;
 }
 
 const Head = ({
@@ -46,12 +47,14 @@ const Head = ({
   titleSuffix,
   url: propsUrl,
   noIndex,
+  keywords: propsKeywords,
 }: HeadProps) => {
   const router = useRouter();
   const url = buildCanonicalUrl(router.basePath, propsUrl || router.asPath);
   const title = formatTitle(titleSuffix, propsTitle);
   const description = propsDescription || "";
   const firstLvlNav = getFirstLvlNav(router.asPath);
+  const keywords = propsKeywords || [];
 
   return (
     <NextHead>
@@ -69,6 +72,7 @@ const Head = ({
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={`${host}/docs/og-image.png`} />
+      <meta property="keywords" content={keywords.join(", ")} />
     </NextHead>
   );
 };

--- a/layouts/DocsPage/DocsPage.tsx
+++ b/layouts/DocsPage/DocsPage.tsx
@@ -30,6 +30,7 @@ const DocsPage = ({
     h1,
     title,
     description,
+    keywords,
     layout,
     videoBanner,
     navigation,
@@ -75,6 +76,7 @@ const DocsPage = ({
         title={title}
         description={description}
         titleSuffix="Teleport Docs"
+        keywords={keywords}
       />
       <SiteHeader />
       <main className={styles.wrapper}>

--- a/layouts/DocsPage/types.ts
+++ b/layouts/DocsPage/types.ts
@@ -74,7 +74,7 @@ export interface PageMeta {
   title?: string;
   description?: string;
   h1?: string;
-  keywords: Array<string>;
+  keywords: string[];
   githubUrl: string;
   layout?: LayoutName;
   videoBanner?: VideoBarProps;

--- a/layouts/DocsPage/types.ts
+++ b/layouts/DocsPage/types.ts
@@ -74,6 +74,7 @@ export interface PageMeta {
   title?: string;
   description?: string;
   h1?: string;
+  keywords: Array<string>;
   githubUrl: string;
   layout?: LayoutName;
   videoBanner?: VideoBarProps;


### PR DESCRIPTION
This PR adjusts docs to accepts `keywords: []` frontmatter and create an HTML meta tag for them. Our Algolia crawler config is already set up to process keywords, but has none to index.

https://github.com/gravitational/teleport/pull/22145 adds a small sample of keywords to test on.