### PR TITLE
Pass through desired value for scopeOnly in workaround

### DIFF
--- a/server/rehype-mdx-to-hast.ts
+++ b/server/rehype-mdx-to-hast.ts
@@ -47,7 +47,7 @@ export default function rehypeMdxToHast(): Transformer {
                 if (prop.name === "scopeOnly") {
                   return {
                     ...result,
-                    [prop.name]: null,
+                    [prop.name]: prop?.value?.value || null,
                   };
                   // Temporary fix for scope={["oss", "cloud"]}, will transform value
                   // to scope="oss,cloud". Can be removed after docs update.


### PR DESCRIPTION
It appears that in the workaround for the `scopeOnly` prop the desired value was discarded. This PR adds that value back in with a `null` fallback to retain the previous functionality in the event no value is found.

I believe that this workaround is in place until the `scopeOnly` prop values can be updated from boolean to string values as done elsewhere in https://github.com/gravitational/docs/pull/225.