### PR TITLE
Allow expanded ToC

### DIFF
--- a/components/AnchorNavigation/AnchorNavigation.module.css
+++ b/components/AnchorNavigation/AnchorNavigation.module.css
@@ -24,6 +24,15 @@
   color: var(--color-darkest);
   border-bottom: 1px solid var(--color-lightest-gray);
 }
+.ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.ulSub {
+  list-style-type: none;
+  padding-left: 10px;
+}
 
 .link {
   display: block;

--- a/components/AnchorNavigation/AnchorNavigation.tsx
+++ b/components/AnchorNavigation/AnchorNavigation.tsx
@@ -13,13 +13,25 @@ const AnchorNavigation = ({ className, headers }: AnchorNavigationProps) => {
     <nav className={cn(styles.wrapper, className)}>
       <div className={styles.menu}>
         <div className={styles.header}>Table of Contents</div>
-        {headers.map(({ id, title }) => {
-          return (
-            <Link key={id} href={`#${id}`} className={styles.link}>
-              {title}
-            </Link>
-          );
-        })}
+        <ul className={styles.ul}>
+          {headers.map(({ id, title, rank }) => {
+            return rank < 3 ? (
+              <li>
+                <Link key={id} href={`#${id}`} className={styles.link}>
+                  {title}
+                </Link>
+              </li>
+            ) : (
+              <ul className={styles.ulSub}>
+                <li>
+                  <Link key={id} href={`#${id}`} className={styles.link}>
+                    {title}
+                  </Link>
+                </li>
+              </ul>
+            );
+          })}
+        </ul>
       </div>
     </nav>
   );

--- a/server/docs-helpers.ts
+++ b/server/docs-helpers.ts
@@ -242,8 +242,11 @@ export const getDocsPageProps = async (
   // Transforms page text page to AST
   const AST = await transformToAST(page.data.content, page);
 
+  //If we set 'toc-depth' in page metadata, import the value here for the ToC to use
+  const tocDepth = page.data.frontmatter.tocDepth;
+
   // Generates ToC from the headers in the AST
-  const tableOfContents = getHeaders(AST);
+  const tableOfContents = getHeaders(AST, tocDepth);
 
   return {
     meta: { ...page.data.frontmatter, ...pageMeta } as PageMeta,

--- a/server/get-headers.ts
+++ b/server/get-headers.ts
@@ -15,11 +15,11 @@ interface HeaderMeta {
   title: string;
 }
 
-export default function getHeaders(root: Node) {
+export default function getHeaders(root: Node, tocDepth = 2) {
   const headers: HeaderMeta[] = [];
 
   visit(root, "element", (node: Element) => {
-    if (headingRank(node) && headingRank(node) <= 2) {
+    if (headingRank(node) && headingRank(node) <= tocDepth) {
       headers.push({
         rank: headingRank(node),
         id: node.properties?.id as string,


### PR DESCRIPTION
This PR enables us to use `tocDepth` in page frontmatter. Normally our ToC only displays H2s in the ToC, but if an author specifies `3` for `tocDepth`, H3s will be included and indented in the list:

![image](https://user-images.githubusercontent.com/2349184/226744634-ef1649d2-05d5-476d-a55b-100243393ccb.png)

The example image above also serves as the "why" of this PR. There are several pages like that, where the header depth makes sense for the content, but the ToC is pretty useless set to just capture H2s.

A known issue is that this makes a new indented `ul` list for each item with a rank (header number) > 3. This is not very efficient. And if an author sets `tocDepth` to `4`, H3s and H4s would show up on the same line. I'm OK with this for now as a partial fix with room for improvement.