### PR TITLE
Force tocDepth to number

### DIFF
--- a/server/docs-helpers.ts
+++ b/server/docs-helpers.ts
@@ -32,6 +32,17 @@ export const getVersion = (filepath: string) => {
   return result ? result[1] : "";
 };
 
+const getTocDepth = (frontmatterDepth: unknown) => {
+  let tocDepth = 2; // default to 2
+  if (typeof frontmatterDepth === "string") {
+    const newDepth = parseInt(frontmatterDepth);
+    if (!isNaN(newDepth)) {
+      tocDepth = newDepth;
+    }
+  }
+  return tocDepth;
+};
+
 /**
  * The function is needed to find the corresponding object in the navigation
  * by the passed page path. Since the navigation has a multi-level structure,
@@ -243,7 +254,7 @@ export const getDocsPageProps = async (
   const AST = await transformToAST(page.data.content, page);
 
   //If we set 'toc-depth' in page metadata, import the value here for the ToC to use
-  const tocDepth = page.data.frontmatter.tocDepth || "2";
+  const tocDepth = getTocDepth(page.data.frontmatter.tocDepth);
 
   // Generates ToC from the headers in the AST
   const tableOfContents = getHeaders(AST, tocDepth);

--- a/server/get-headers.ts
+++ b/server/get-headers.ts
@@ -15,7 +15,7 @@ interface HeaderMeta {
   title: string;
 }
 
-export default function getHeaders(root: Node, tocDepth) {
+export default function getHeaders(root: Node, tocDepth: number) {
   const headers: HeaderMeta[] = [];
 
   visit(root, "element", (node: Element) => {


### PR DESCRIPTION
This will ensure that no matter what someone enters into the frontmatter for `tocDepth`, it'll always default to 2. It also won't allow random strings like "hello" as a tocDepth

Feel free to skip if its overthe top