### PR TITLE
Add nav link to /integrations/

### DIFF
--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -23,10 +23,10 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  width: 150px;
-  min-width: 150px;
+  width: 125px;
+  min-width: 125px;
   height: 24;
-  padding: 0 var(--m-2);
+  padding: 0 var(--m-1);
   color: var(--color-dark-purple);
   font-size: var(--fs-text-xl);
   font-weight: 700;
@@ -38,6 +38,8 @@
     width: 200px;
   }
   @media (--sm-scr) {
+    width: 150px;
+    min-width: 150px;
     height: var(--m-6);
     padding: 0 var(--m-2);
     line-height: var(--m-6);

--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -112,6 +112,7 @@ const menu: MenuCategoryProps[] = [
       },
     ],
   },
+  { title: "Integrations", href: "/integrations/", testId: "integrations" },
   {
     title: "Documentation",
     href: "/",

--- a/tests/data/navbar-data.ts
+++ b/tests/data/navbar-data.ts
@@ -155,6 +155,11 @@ export const navigationData: NavbarData = [
     },
   },
   {
+    button: { title: "Integrations", testId: "integrations" },
+    href: "/integrations/",
+    isExternal: true,
+  },
+  {
     button: { title: "Documentation", testId: "docs" },
     menu: {
       title: "Teleport Documentation",


### PR DESCRIPTION
Preview: https://docs-git-pietikinnunen-integrations-link-goteleport.vercel.app/docs/

- Added Integrations link to header navigation
- Reduced Teleport logo width and padding on md screens so the navigation links fit better

The Integrations page has not been published yet https://github.com/gravitational/next/pull/1847.

Related Asana task: https://app.asana.com/0/1202613463734613/1204276873579610/f