### PR TITLE
Make the spellcheck script more usable in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "spellcheck": "find content -mindepth 1 -maxdepth 1 -type d | xargs -I{} bash scripts/check-spelling.sh {}",
+    "spellcheck": "bash scripts/check-spelling.sh",
     "git-update": "git submodule update --init --remote",
     "build-node": "rm -rf .build && tsc --build tsconfig.node.json && tsc-esm-fix --target='.build' --ext='.mjs'",
     "generate-sitemap": "node ./scripts/generate-sitemap.mjs",

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -1,8 +1,37 @@
 # $1 is the content directory in which to check spelling. A content directory is
 # a git submodule pointing to a branch of the gravitational/teleport repository.
 
+if [ $# -eq 0 ]; then
+
+    cat<<EOF
+
+You must provide an argument to the spellcheck script. The argument must be the
+path to a content directory, which is either:
+
+- A subdirectory of "content" within a gravitational/docs clone
+- The root of a gravitational/teleport clone
+
+EOF
+exit 1;
+fi
+
+if [ ! -e $1/docs/cspell.json ]; then
+
+    cat<<EOF
+
+We could not find $1/docs/cspell.json. Make sure you run the spellcheck script
+on either:
+
+- A subdirectory of "content" within a gravitational/docs clone
+- The root of a gravitational/teleport clone
+
+EOF
+exit 1;
+fi
+
 npx cspell lint --no-progress --config $1/docs/cspell.json $1/docs/pages/**/*.mdx;
-if [ $? -ne 0 ]; then
+RES=$?;
+if [ $RES -ne 0 ]; then
   cat<<EOF
 
 There are spelling issues in one or more pages within $1/docs/pages (see the
@@ -10,5 +39,6 @@ logs above). Either fix the misspellings or, if these are not actually issues,
 edit the list of ignored words in $1/docs/cspell.json.
 
 EOF
+exit $RES;
 fi
 


### PR DESCRIPTION
- Previously, the `yarn spellcheck` script exited with a zero status if the `cspell` command exited with an error. This fixes that.

- Require an argument to the `yarn spellcheck` command rather than checking the spelling in all content directories by default. This will make it easier to run this command in CI, where the content directory structure differs a bit from a standard gravitational/docs clone (i.e., there's one content directory, not three, and the content directory is not named after a version of the docs).