### PR TITLE
Use Next Font local for fonts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "classnames": "^2.3.1",
     "date-fns": "^2.27.0",
     "next": "13.2.4",
+    "@next/font": "13.3.0",
     "posthog-js": "^1.38.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,9 +5,53 @@ import type { AppProps } from "next/app";
 import { DocsContextProvider } from "layouts/DocsPage/context";
 import { posthog, sendPageview } from "utils/posthog";
 
+// https://larsmagnus.co/blog/how-to-optimize-custom-fonts-with-next-font
+// Next Font to enable zero layout shift which is hurting SEO.
+import localUbuntu from "@next/font/local";
+import localLato from "@next/font/local";
+const ubuntu = localUbuntu({
+  src: "../styles/assets/ubuntu-mono-400.woff2",
+  variable: "--font-ubunt",
+  display: "swap",
+});
+const lato = localLato({
+  src: [
+    {
+      path: "../styles/assets/lato-400.woff2",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../styles/assets/lato-400-italic.woff2",
+      weight: "400",
+      style: "italic",
+    },
+    {
+      path: "../styles/assets/lato-700.woff2",
+      weight: "700",
+      style: "normal",
+    },
+    {
+      path: "../styles/assets/lato-700-italic.woff2",
+      weight: "700",
+      style: "italic",
+    },
+    {
+      path: "../styles/assets/lato-900.woff2",
+      weight: "900",
+      style: "normal",
+    },
+    {
+      path: "../styles/assets/lato-900-italic.woff2",
+      weight: "900",
+      style: "italic",
+    },
+  ],
+  variable: "--font-lato",
+  display: "swap",
+});
+
 import "styles/varaibles.css";
-import "styles/fonts-ubuntu.css";
-import "styles/fonts-lato.css";
 import "styles/global.css";
 import "styles/algolia-search.css";
 
@@ -93,6 +137,12 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
 
   return (
     <>
+      <style jsx global>{`
+        :root {
+          --font-base: ${lato.style.fontFamily};
+          --font-ubunt: ${ubuntu.style.fontFamily};
+        }
+      `}</style>
       <Analytics />
       <DocsContextProvider>
         <Component {...pageProps} />

--- a/styles/global.css
+++ b/styles/global.css
@@ -5,5 +5,5 @@ body {
 }
 
 body {
-  font-family: var(--font-body);
+  font-family: var(--font-base);
 }

--- a/styles/varaibles.css
+++ b/styles/varaibles.css
@@ -22,9 +22,9 @@
   --color-note: #009cf1;
 
   /* fonts */
-  --font-body: "Lato", sans-serif;
+  --font-body: var(--font-base);
   --font-serif: "Georgia", serif;
-  --font-monospace: "Ubuntu Mono", monospace;
+  --font-monospace: var(--font-ubunt);
 
   /* font sizes */
   --fs-text-xs: 10px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,6 +1674,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.3.0.tgz#790c5444348fad7aabbfc35a45bfc50505219725"
+  integrity sha512-xUv7VRUA2Zr6n/KJDILyv7/zGy9xKUsyQURaQqYr7lVxn0REScazwyZQzhSm+DnJoUyo+9DcFs2J3WsZXHUvQw==
+
 "@next/swc-android-arm-eabi@13.2.4":
   version "13.2.4"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz#758d0403771e549f9cee71cbabc0cb16a6c947c0"


### PR DESCRIPTION
I noticed that our core web vitals is off for the docs on mobile, which is a result of https://web.dev/cls/. 

The only shift I'm seeing is due to the webfont loading, this PR will fix it. 

<img width="891" alt="image" src="https://user-images.githubusercontent.com/559288/231017267-ff514c99-00e4-412b-a31b-cc0c5a7e3724.png">

### Before
<img width="901" alt="image" src="https://user-images.githubusercontent.com/559288/231019768-6d008ad0-13a5-4b59-a2ee-736a464470c0.png">

### After
<img width="635" alt="image" src="https://user-images.githubusercontent.com/559288/231020029-a1a34a5d-6429-4a33-8412-5503d79d25ba.png">
<img width="783" alt="image" src="https://user-images.githubusercontent.com/559288/231020047-207ea448-5be0-494d-8173-0647280e2074.png">
