### PR TITLE
Disable the frontmatter linter

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -71,7 +71,9 @@ const configLint = {
     ["validate-links", { repository: false }],
     [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
     [remarkLintDetails, ["error"]],
-    [remarkLintFrontmatter, ["error"]],
+    // Disabling the remarkLintFrontmatter check until we fix
+    // gravitational/docs#80
+    // [remarkLintFrontmatter, ["error"]],
     [
       remarkLintMessaging,
       loadMessagingConfig(resolve("messaging-config.json")),


### PR DESCRIPTION
If you run `yarn markdown-lint` in a local `gravitational/docs` clone after loading all submodules, this linter catches duplicate titles/descriptions across docs versions, creating a lot of noise that interferes with being able to reproduce linter violations in CI locally.

Our GitHub Actions workflows for `gravitational/teleport` only check a single submodule, so this linter doesn't catch duplicate titles/descriptions between versions of the docs in CI.

Once we fix gravitational/docs#80, we can re-enable this linter.