### PR TITLE
Use version agnostic links in Navigation

### DIFF
--- a/layouts/DocsPage/DocsPage.tsx
+++ b/layouts/DocsPage/DocsPage.tsx
@@ -20,6 +20,7 @@ import Navigation, { getCurrentCategoryIndex } from "./Navigation";
 import Feedback from "components/Feedback";
 
 import styles from "./DocsPage.module.css";
+import { useVersionAgnosticPages } from "utils/useVersionAgnosticPages";
 
 export interface DocsPageProps {
   meta: PageMeta;
@@ -49,6 +50,7 @@ const DocsPage = ({
 
   const { current, latest, available } = versions;
   const getPath = useFindDestinationPath(versions);
+  const { isVersionAgnosticPage } = useVersionAgnosticPages();
 
   useEffect(() => {
     setVersions(versions);
@@ -92,6 +94,7 @@ const DocsPage = ({
             getNewVersionPath={getPath}
             latest={latest}
             scopes={scopes}
+            isVersionAgnosticPage={isVersionAgnosticPage(route)}
           />
           {videoBanner && (
             <VideoBar className={styles.video} {...videoBanner} />

--- a/layouts/DocsPage/Header.tsx
+++ b/layouts/DocsPage/Header.tsx
@@ -17,6 +17,7 @@ interface DocHeaderProps {
   githubUrl?: string;
   latest?: string;
   versions?: VersionsInfo;
+  isVersionAgnosticPage: boolean;
   getNewVersionPath?: (ver: string) => string;
 }
 
@@ -29,6 +30,7 @@ const DocHeader = ({
   getNewVersionPath,
   latest,
   scopes,
+  isVersionAgnosticPage,
 }: DocHeaderProps) => {
   return (
     <section className={styles.wrapper}>
@@ -46,7 +48,7 @@ const DocHeader = ({
         <p className={styles.subtitle}>Teleport</p>
         <h1 className={styles.title}>{title}</h1>
         <div className={styles.dropdowns}>
-          {versions && latest && (
+          {versions && latest && !isVersionAgnosticPage && (
             <Versions
               {...versions}
               className={styles.versions}

--- a/layouts/DocsPage/Navigation.tsx
+++ b/layouts/DocsPage/Navigation.tsx
@@ -1,6 +1,5 @@
 import cn from "classnames";
 import { useState, useCallback, useEffect } from "react";
-import { useRouter } from "next/router";
 import HeadlessButton from "components/HeadlessButton";
 import Search from "components/Search";
 import Icon from "components/Icon";
@@ -12,6 +11,7 @@ import {
   ScopesInMeta,
 } from "./types";
 import styles from "./Navigation.module.css";
+import { useVersionAgnosticPages } from "utils/useVersionAgnosticPages";
 
 const SCOPELESS_HREF_REGEX = /\?|\#/;
 
@@ -60,8 +60,8 @@ const DocsNavigationItems = ({
   entries,
   onClick,
 }: DocsNavigationItemsProps) => {
-  const router = useRouter();
   const docPath = useCurrentHref().split(SCOPELESS_HREF_REGEX)[0];
+  const { getVersionAgnosticRoute } = useVersionAgnosticPages();
 
   return (
     <>
@@ -79,7 +79,7 @@ const DocsNavigationItems = ({
                   active && styles.active,
                   selected && styles.selected
                 )}
-                href={entry.slug}
+                href={getVersionAgnosticRoute(entry.slug)}
                 onClick={onClick}
               >
                 {entry.title}

--- a/pages/older-versions/index.tsx
+++ b/pages/older-versions/index.tsx
@@ -19,7 +19,11 @@ const OldVersions = () => {
       <SiteHeader />
       <main className={styles.wrapper}>
         <div className={styles.body}>
-          <Header title={title} scopes={["noScope"]} />
+          <Header
+            title={title}
+            scopes={["noScope"]}
+            isVersionAgnosticPage={true}
+          />
           <div className={styles.content}>
             <p>
               Deprecated versions of the Teleport docs can be found at the

--- a/utils/useVersionAgnosticPages.ts
+++ b/utils/useVersionAgnosticPages.ts
@@ -1,0 +1,22 @@
+import { getPathWithoutVersion } from "./url";
+
+const agnost = ["preview/upcoming-releases/", "changelog/"];
+
+export const useVersionAgnosticPages = () => {
+  const isVersionAgnosticPage = (route: string) => {
+    const path = getPathWithoutVersion(route);
+    return agnost.includes(path);
+  };
+
+  const getVersionAgnosticRoute = (route: string) => {
+    if (isVersionAgnosticPage(route)) {
+      return `/${getPathWithoutVersion(route)}`;
+    }
+    return route;
+  };
+
+  return {
+    isVersionAgnosticPage,
+    getVersionAgnosticRoute,
+  };
+};


### PR DESCRIPTION
Not ready to merge or for review, but just toying with ideas, rambling, and getting a vercel branch build going.

For now, this just does two things
1. gets version agnostic links if the "route with version" is inside my array
2. hides the version picker on the pages that ARE agnostic (maybe? should we?)

I did have some useEffect stuff that could `router.replace` a path to its not versioned route but i don't really like using useEffect for redirects. I also checked the redirect paths in the `config.json` stuff and they are version unaware. So, still tinkering.

if you wanna test it out, go to any page, change the version and then navigate to the preview or changelog pages

happy for other thoughts or ideas or stuff i missed