### PR TITLE
Require capitalizing "Teleport" in the docs

### DIFF
--- a/messaging-config.json
+++ b/messaging-config.json
@@ -1,5 +1,11 @@
 [
   {
+    "incorrect": "(?<!`)teleport(?!`)",
+    "correct": "`teleport` or Teleport",
+    "explanation": "capitalize \"Teleport\" unless you are describing the binary, in which case use code style",
+    "where": ["headers", "title", "body"]
+  },
+  {
     "incorrect": "\\W(machine id|(database|app(lication)?|desktop|kubernetes|ssh|discovery) service)\\W",
     "correct": "capitalize the names of Teleport services",
     "explanation": "We want to ensure that product names are consistent across the docs"


### PR DESCRIPTION
Some parts of the docs say "teleport" where they should say "Teleport". This change edits the messaging linter config to flag uses of "teleport" that are not wrapped in backticks. The exception is in code comments and descriptions, where backticks don't render.