### PR TITLE
Get Mermaid support to work during deployments

### DIFF
--- a/puppeteerConfig.json
+++ b/puppeteerConfig.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox"]
+}

--- a/server/remark-mermaid.ts
+++ b/server/remark-mermaid.ts
@@ -46,8 +46,8 @@ function render(
     fs.outputFileSync(tmpMmdFilePath, source);
 
     const command = configFilePath
-      ? `${mmdcExecutable} -q  -i ${tmpMmdFilePath} -o ${svgFilePath} -b transparent --configFile ${configFilePath}`
-      : `${mmdcExecutable} -q -i ${tmpMmdFilePath} -o ${svgFilePath} -b transparent`;
+      ? `${mmdcExecutable} -i ${tmpMmdFilePath} -o ${svgFilePath} -p puppeteerConfig.json -b transparent --configFile ${configFilePath}`
+      : `${mmdcExecutable} -i ${tmpMmdFilePath} -o ${svgFilePath} -p puppeteerConfig.json -b transparent`;
 
     // Invoke mermaid.cli
     execSync(command);


### PR DESCRIPTION
The docs engine builds Mermaid diagrams by generating SVGs using Chromium. Since the Vercel build runner runs as root, we need to disable the Chromium sandbox in order to generate SVGs without Chromium exiting with an error message. This change adds a Puppeteer config that the Mermaid CLI can use to disable the sandbox when running Chromium.