### PR TITLE
Default Details blocks to closed

### DIFF
--- a/components/Details/Details.tsx
+++ b/components/Details/Details.tsx
@@ -27,7 +27,7 @@ export interface DetailsProps {
 export const Details = ({
   scope,
   scopeOnly = false,
-  opened,
+  opened = false,
   title,
   min,
   children,
@@ -38,7 +38,7 @@ export const Details = ({
   } = useContext(DocsContext);
   const router = useRouter();
   const scopes = useMemo(() => getScopes(scope), [scope]);
-  const [isOpened, setIsOpened] = useState<boolean>(Boolean(opened));
+  const [isOpened, setIsOpened] = useState(opened);
   const isInCurrentScope = scopes.includes(currentScope);
   const detailsId = title ? transformTitleToAnchor(title) : "title";
   const anchorInPath = getAnchor(router.asPath);


### PR DESCRIPTION
Resolves #278

This adjusts the Details block to be closed by default. It now uses @avatus's suggestion

> My proposed solution is to follow the ["props default to true" convention](https://legacy.reactjs.org/docs/jsx-in-depth.html#props-default-to-true).

Once merged we can merge the followup PR for `teleport` removing the `opened` var where set to `false`.