### PR TITLE
adds a note about yarn git-update taking a long time

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To update docs to the latest version from master, run:
 yarn git-update
 ```
 
+(Note that the `git-update` operation may take 20+ minutes to complete)
+
 Install dependencies with:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "spellcheck": "bash scripts/check-spelling.sh",
-    "git-update": "git submodule update --init --remote",
+    "git-update": "git submodule update --init --remote --progress",
     "build-node": "rm -rf .build && tsc --build tsconfig.node.json && tsc-esm-fix --target='.build' --ext='.mjs'",
     "generate-sitemap": "node ./scripts/generate-sitemap.mjs",
     "generate-article-links": "node ./scripts/generate-article-links.mjs",


### PR DESCRIPTION
I thought this operation was broken or otherwise hanging on me for some reason, but it looks like this command just clones teleport multiple times, and teleport's repo is huge so it takes a long time to complete. This adds a note so users know to expect this.

Also adds the --progress flag so that the user gets some feedback as the operation completes.