### PR TITLE
Remove wordbreak from code elements

### DIFF
--- a/components/MDX/Code.module.css
+++ b/components/MDX/Code.module.css
@@ -3,6 +3,5 @@
   border: 1px solid var(--color-light-gray);
   border-radius: var(--r-sm);
   font-size: var(--fs-text-md);
-  word-break: break-word;
   background-color: var(--color-lightest-gray);
 }


### PR DESCRIPTION
DO NOT MERGE
Not yet ready to merge, but I don't want to make it DRAFT so I can see a vercel preview build. Definitely fixes a lot of pages

Examples to compare to live/preview deploy: 
1. [current](https://goteleport.com/docs/access-controls/guides/moderated-sessions/#require_session_join) | [proposed](https://docs-git-michaelmyers-remove-word-break-goteleport.vercel.app//docs/access-controls/guides/moderated-sessions/#require_session_join)
2. [current](https://goteleport.com/docs/management/diagnostics/metrics/) | [proposed](https://docs-git-michaelmyers-remove-word-break-goteleport.vercel.app/docs/management/diagnostics/metrics/)
3. this one is a _little_ better but still has some issues [current](https://goteleport.com/docs/reference/cli/) | [proposed](https://docs-git-michaelmyers-remove-word-break-goteleport.vercel.app/docs/reference/cli/)