### PR TITLE
Disable mid-word breaking for the code in the table columns

### DIFF
--- a/components/MDX/Tags.module.css
+++ b/components/MDX/Tags.module.css
@@ -79,6 +79,10 @@
   line-height: var(--lh-md);
   padding: var(--m-2);
 
+  & code {
+    white-space: pre;
+  }
+
   @media (--sm-scr) {
     font-size: var(--fs-text-md);
   }


### PR DESCRIPTION
Solves the issue with unpretty table columns' width and cutting of long code strings https://github.com/gravitational/docs/issues/126
Here was described the approach to solve it (disable mid-word breaking for the code in the table columns) https://github.com/gravitational/docs/issues/126#issuecomment-1577251165 + some details.

Attached the video with the result here:
https://github.com/gravitational/docs/assets/78731462/deccce23-7b09-4e2d-b209-3fd0983df6b3
