### PR TITLE
Provided Vars to more than "code" code blocks, fixed remarking code logic

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -69,7 +69,7 @@ const configLint = {
     // include variables in their references, e.g.,
     // [CM-08 Information System Component Inventory]((=fedramp.control_url=)CM-8)
     ["validate-links", { repository: false }],
-    [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
+    [remarkCodeSnippet, { lint: true, langs: codeFormats }],
     [remarkLintDetails, ["error"]],
     [remarkLintFrontmatter, ["error"]],
     [

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -69,7 +69,7 @@ const configLint = {
     // include variables in their references, e.g.,
     // [CM-08 Information System Component Inventory]((=fedramp.control_url=)CM-8)
     ["validate-links", { repository: false }],
-    [remarkCodeSnippet, { lint: true, langs: codeFormats }],
+    [remarkCodeSnippet, { lint: true, langs: ["code", "bash"] }],
     [remarkLintDetails, ["error"]],
     [remarkLintFrontmatter, ["error"]],
     [

--- a/components/Code/Code.module.css
+++ b/components/Code/Code.module.css
@@ -89,3 +89,21 @@
     }
   }
 }
+
+.line {
+  display: block;
+  & :global {
+    & .wrapper-input input {
+      color: var(--color-light-blue);
+      background-color: transparent;
+    }
+
+    & .wrapper-input input::placeholder {
+      color: var(--color-light-gray);
+    }
+
+    & .wrapper-input svg {
+      color: var(--color-light-blue);
+    }
+  }
+}

--- a/components/Code/Code.tsx
+++ b/components/Code/Code.tsx
@@ -1,6 +1,14 @@
 import cn from "classnames";
 import styles from "./Code.module.css";
 
+export interface CodeLineProps {
+  children: React.ReactNode;
+}
+
+export function CodeLine(props: CodeLineProps) {
+  return <span className={styles.line} {...props} />;
+}
+
 export type CodeProps = {
   children: React.ReactNode;
   className?: string;

--- a/components/Code/index.ts
+++ b/components/Code/index.ts
@@ -1,1 +1,1 @@
-export { Code as default } from "./Code";
+export { Code as default, CodeLine } from "./Code";

--- a/components/Snippet/Snippet.module.css
+++ b/components/Snippet/Snippet.module.css
@@ -1,6 +1,6 @@
 .wrapper {
   & pre {
-    color: #75715e;
+    color: #A9A590;
   }
 }
 

--- a/components/Variables/Var.module.css
+++ b/components/Variables/Var.module.css
@@ -10,7 +10,7 @@
   z-index: 1;
   padding: var(--m-0-5) var(--m-3) var(--m-0-5) var(--m-0-5);
   font-family: var(--font-monospace);
-  font-size: var(--fs-text-lg);
+  font-size: var(--fs-text-md);
   color: var(--color-light-blue);
   border: 1px solid transparent;
   border-radius: var(--r-default);

--- a/layouts/DocsPage/components.tsx
+++ b/layouts/DocsPage/components.tsx
@@ -38,11 +38,13 @@ import {
   IFrame,
   Pre,
 } from "components/MDX";
+import { CodeLine } from "components/Code";
 
 export const components = {
   a: Link,
   code: Code,
   inlineCode: Code,
+  codeline: CodeLine,
   // eslint-disable-next-line jsx-a11y/alt-text
   img: (props) => <Image {...props} />, // needed to circumvent props mismatch in types
   iframe: IFrame,

--- a/server/code-langs.ts
+++ b/server/code-langs.ts
@@ -1,0 +1,16 @@
+// List of languages in MDX which should support custom plugins such as code snippet remarking
+export const codeLangs = [
+  "code",
+  "yaml",
+  "sh",
+  "shell",
+  "bash",
+  "toml",
+  "json",
+  "ini",
+  "go",
+  "sql",
+  "systemd",
+  "powershell",
+  "protobuf",
+];

--- a/server/fixtures/includes/includes-var-after-commands.mdx
+++ b/server/fixtures/includes/includes-var-after-commands.mdx
@@ -1,0 +1,11 @@
+## Header
+
+```code
+$ aws iam create-policy --policy-name<Var name="kube-iam-policy"/>
+# some comment
+"Policy": {
+  "PolicyName": "<Var name="kube-iam-policy"/>",
+  "PolicyId": "ANPAW2Y2Q2Y2Y2Y2Y2Y2Y",
+  "Arn": "arn:aws:iam::aws:policy/"<Var name="kube-iam-policy"/>
+}
+```

--- a/server/fixtures/includes/includes-var-in-yaml.mdx
+++ b/server/fixtures/includes/includes-var-in-yaml.mdx
@@ -1,0 +1,12 @@
+## Header
+
+```yaml
+teleport:
+  identitySecretName: "teleport-plugin-jira-identity"
+  address: <Var name="teleport-address"/>
+# /etc/teleport.yaml
+auth_service:
+  # ...
+  ca_key_params:
+    keyring: <Var name="keyring"/>
+```

--- a/server/fixtures/result/code-snippet-heredoc.mdx
+++ b/server/fixtures/result/code-snippet-heredoc.mdx
@@ -63,9 +63,9 @@
     </CommandLine>
   </Command>
 
-  <CommandComment>
+  <CodeLine>
 
-  </CommandComment>
+  </CodeLine>
 
   <CommandComment data-type="descr">
     Create role

--- a/server/fixtures/result/var-after-commands.mdx
+++ b/server/fixtures/result/var-after-commands.mdx
@@ -1,0 +1,45 @@
+## Header
+
+<Snippet>
+  <Command>
+    <CommandLine data-content="$ ">
+      aws iam create-policy --policy-name
+
+      <Var name="kube-iam-policy" isGlobal="false" description="" />
+
+
+    </CommandLine>
+  </Command>
+
+  <CommandComment data-type="descr">
+    some comment
+  </CommandComment>
+
+  <CodeLine>
+    "Policy": {
+  </CodeLine>
+
+  <CodeLine>
+      "PolicyName": "
+
+    <Var name="kube-iam-policy" isGlobal="false" description="" />
+
+    ",
+  </CodeLine>
+
+  <CodeLine>
+      "PolicyId": "ANPAW2Y2Q2Y2Y2Y2Y2Y2Y",
+  </CodeLine>
+
+  <CodeLine>
+      "Arn": "arn:aws:iam::aws:policy/"
+
+    <Var name="kube-iam-policy" isGlobal="false" description="" />
+
+
+  </CodeLine>
+
+  <CodeLine>
+    }
+  </CodeLine>
+</Snippet>

--- a/server/fixtures/result/var-in-yaml.mdx
+++ b/server/fixtures/result/var-in-yaml.mdx
@@ -1,0 +1,43 @@
+## Header
+
+<Snippet>
+  <CodeLine>
+    teleport:
+  </CodeLine>
+
+  <CodeLine>
+      identitySecretName: "teleport-plugin-jira-identity"
+  </CodeLine>
+
+  <CodeLine>
+      address: 
+
+    <Var name="teleport-address" isGlobal="false" description="" />
+
+
+  </CodeLine>
+
+  <CommandComment data-type="descr">
+    /etc/teleport.yaml
+  </CommandComment>
+
+  <CodeLine>
+    auth_service:
+  </CodeLine>
+
+  <CodeLine>
+      \# ...
+  </CodeLine>
+
+  <CodeLine>
+      ca_key_params:
+  </CodeLine>
+
+  <CodeLine>
+        keyring: 
+
+    <Var name="keyring" isGlobal="false" description="" />
+
+
+  </CodeLine>
+</Snippet>

--- a/server/markdown-config.ts
+++ b/server/markdown-config.ts
@@ -22,6 +22,7 @@ import remarkCopyLinkedFiles from "remark-copy-linked-files";
 import rehypeImages from "./rehype-images";
 import { getVersion, getVersionRootPath } from "./docs-helpers";
 import { loadConfig } from "./config-docs";
+import { codeLangs } from "./code-langs";
 
 // We move images to `.next/static` because this folder is preserved
 // in the cache on rebuilds. If we place them in `public` folder, they will
@@ -49,7 +50,7 @@ export const transformToAST = async (value: string, vfile: VFile) => {
       variables: loadConfig(getVersion(vfile.path)).variables || {},
     }) // Resolves (=variable=) syntax
     .use(remarkCodeSnippet, {
-      langs: ["code"],
+      langs: codeLangs,
     }) // Adds custom code snippets
     .use(remarkLinks) // Makes links absolute and removes mdx extension
     .use(remarkCopyLinkedFiles, {

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -161,6 +161,20 @@ const getCommentNode = (
   ],
 });
 
+const getCodeLine = (
+  content: string,
+  attributes: MdxJsxAttribute[] = []
+): MdxJsxFlowElement => {
+  const children = getChildrenNode(content);
+
+  return {
+    type: "mdxJsxFlowElement",
+    name: "CodeLine",
+    attributes,
+    children: children,
+  };
+};
+
 export interface RemarkCodeSnippetOptions {
   langs: string[];
   lint?: boolean;
@@ -266,7 +280,7 @@ export default function remarkCodeSnippet({
               );
             }
           } else {
-            children.push(getCommentNode(codeLines[i]));
+            children.push(getCodeLine(codeLines[i]));
           }
         }
 

--- a/uvu-tests/remark-code-snippet.test.ts
+++ b/uvu-tests/remark-code-snippet.test.ts
@@ -9,12 +9,13 @@ import mdx from "remark-mdx";
 import remarkCodeSnippet, {
   RemarkCodeSnippetOptions,
 } from "../server/remark-code-snippet";
+import { codeLangs } from "../server/code-langs";
 
 const transformer = (
   options: VFileOptions,
   pluginOptions: RemarkCodeSnippetOptions = {
     resolve: true,
-    langs: ["code", "bash"],
+    langs: codeLangs,
   }
 ) =>
   remark()
@@ -180,6 +181,44 @@ Suite("Variables in command support", () => {
 
   const expected = readFileSync(
     resolve("server/fixtures/result/var-in-command.mdx"),
+    "utf-8"
+  );
+
+  assert.equal(result, expected);
+});
+
+Suite("Variables in yaml support", () => {
+  const value = readFileSync(
+    resolve("server/fixtures/includes/includes-var-in-yaml.mdx"),
+    "utf-8"
+  );
+
+  const result = transformer({
+    value,
+    path: "/docs/index.mdx",
+  }).toString();
+
+  const expected = readFileSync(
+    resolve("server/fixtures/result/var-in-yaml.mdx"),
+    "utf-8"
+  );
+
+  assert.equal(result, expected);
+});
+
+Suite("Variables in code after command support", () => {
+  const value = readFileSync(
+    resolve("server/fixtures/includes/includes-var-after-commands.mdx"),
+    "utf-8"
+  );
+
+  const result = transformer({
+    value,
+    path: "/docs/index.mdx",
+  }).toString();
+
+  const expected = readFileSync(
+    resolve("server/fixtures/result/var-after-commands.mdx"),
     "utf-8"
   );
 


### PR DESCRIPTION
Solves https://github.com/gravitational/docs/issues/186.
The problem that invoked bug https://github.com/gravitational/teleport/pull/26636 was in the function `remarkCodeSnippet`: if a line wasn't connected to commands, and it wasn't a comment, it still defined as `CommandComment`, which hasn't got logic to detect Vars inside. So inside the `code` block but after the `CommandLine` variables weren't recognized.
I fixed the logic inside the last `else` in the condition: now `CommandComment` is a line that related to commands and that begins with grate as intended; all other lines that are not commands, vars, comments, etc are the `CodeLine`, and they support `Vars` inside like commands.
To cover the case that invoked the bug, I added a new uvu-test.

The next thing that was done is provide Vars supporting not only in `code` code blocks. To do it, I added the list of languages in MDX syntax that should support code snippet remarking. It includes languages and formats which are used in the content (let me know if some language from this list seems useless to you for this feature, and it can be removed from the list altogether).
Also, added the test to cover the correctness of support for new MDX languages in this list (yaml is taken as an example).

Also, added a few minor visual changes:
- Made font-size of Vars slightly smaller (based on the comment https://github.com/gravitational/docs/issues/186#issuecomment-1570148841);
- Made color of the font inside snippet-wrapper 20% lighter because I noticed places where there was a pretty low contrast with black snippet background.

After merging this PR, Vars in the code output on the Register Cluster page can be successfully returned (that were removed in this PR https://github.com/gravitational/teleport/pull/26636):
![fix](https://github.com/gravitational/docs/assets/78731462/e37da3ee-9931-465c-a7db-63ed903393cf)
Last thing to consider is the most part of code-highlighting is not supported along with variable syntax, it requires a lot of time to support these features together. When we discussed the scope of tasks with Sasha Klizhentas, I warned about that, and he agreed that preserving highlighting here wouldn't be too important.
So the appearance of yaml code block will be like this:
![yaml](https://github.com/gravitational/docs/assets/78731462/dbbc6843-fbd3-4125-b428-a1e5792dd6eb)

