### PR TITLE
Allow docs images to pop up

### DIFF
--- a/components/MDX/Image.module.css
+++ b/components/MDX/Image.module.css
@@ -32,7 +32,7 @@
 }
 
 .overlay {
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: rgba(0, 0, 0, 0.7);
   width: 100vw;
   height: 100%;
   min-width: 100%;
@@ -41,22 +41,27 @@
   z-index: 3002;
   transform: translate(-50%, -50%);
   position: fixed;
-  cursor: pointer;
+  cursor: zoom-out;
 }
 
-.clickable {
-  cursor: pointer;
+.zoomable {
+  cursor: zoom-in;
+  cursor: -moz-zoom-in; 
+  cursor: -webkit-zoom-in;
 }
 
-.modal {
+.dialog {
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   background: white;
+  cursor: zoom-out;
+  cursor: -moz-zoom-out; 
+  cursor: -webkit-zoom-out;
   z-index: 3002;
   & .image {
-    max-width: 93vw;
-    max-height: 93vh;
+    max-width: 95vw;
+    max-height: 95vh;
   }
 }

--- a/components/MDX/Image.module.css
+++ b/components/MDX/Image.module.css
@@ -30,3 +30,33 @@
   color: var(--color-gray);
   font-style: italic;
 }
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.8);
+  width: 100vw;
+  height: 100%;
+  min-width: 100%;
+  top: 50%;
+  left: 50%;
+  z-index: 3002;
+  transform: translate(-50%, -50%);
+  position: fixed;
+  cursor: pointer;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  z-index: 3002;
+  & .image {
+    max-width: 93vw;
+    max-height: 93vh;
+  }
+}

--- a/components/MDX/Image.tsx
+++ b/components/MDX/Image.tsx
@@ -1,34 +1,100 @@
 import cn from "classnames";
-import { Children, cloneElement, useMemo } from "react";
+import {
+  Children,
+  cloneElement,
+  useCallback,
+  useRef,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from "react";
 import NextImage, { ImageProps as NextImageProps } from "next/image";
 import styles from "./Image.module.css";
+import {
+  useClickOutside,
+  useEscape,
+  useDisableBodyScroll,
+} from "server/custom-hooks";
 
 type PositioningValue = "left" | "center" | "right";
 interface SharedProps {
   align?: PositioningValue;
   bordered?: boolean;
   caption?: string;
+  noPopUp?: boolean;
 }
 
+//** Maximum width of content block where images are placed.
+/* If the original image is smaller, then there is no sense to expand the image by clicking. */
+const MAX_CONTENT_WIDTH = 900;
+
 export type ImageProps = SharedProps & NextImageProps;
+
+type ModalImageProps = {
+  setShowExpandedImage: Dispatch<SetStateAction<boolean>>;
+} & ImageProps;
+
+const ModalImage = ({ setShowExpandedImage, ...props }: ModalImageProps) => {
+  const closeHandler = useCallback(
+    () => setShowExpandedImage(false),
+    [setShowExpandedImage]
+  );
+  const modalRef = useRef<HTMLDivElement>();
+  useClickOutside(modalRef, closeHandler);
+  useEscape(closeHandler);
+
+  return (
+    <>
+      <div className={styles.overlay} />
+      <div className={styles.modal} ref={modalRef}>
+        <NextImage className={styles.image} {...props} />
+      </div>
+    </>
+  );
+};
 
 export const Image = ({
   align = "left",
   bordered,
   caption,
+  noPopUp = false,
   ...props
 }: ImageProps) => {
+  const [showExpandedImage, setShowExpandedImage] = useState(false);
+  const shouldExpand = !noPopUp && props.width > MAX_CONTENT_WIDTH;
+  useDisableBodyScroll(showExpandedImage);
+  const handleClickImage = () => {
+    if (shouldExpand) {
+      setShowExpandedImage(true);
+    }
+  };
+
   return (
-    <span className={cn(styles.wrapper, styles[align])}>
-      {bordered ? (
-        <span className={styles.border}>
-          <NextImage {...props} className={styles.image} />
-        </span>
-      ) : (
-        <NextImage {...props} className={styles.image} />
+    <>
+      <span className={cn(styles.wrapper, styles[align])}>
+        {bordered ? (
+          <span className={styles.border}>
+            <NextImage
+              {...props}
+              className={cn(styles.image, shouldExpand && styles.clickable)}
+              onClick={handleClickImage}
+            />
+          </span>
+        ) : (
+          <NextImage
+            {...props}
+            className={cn(styles.image, shouldExpand && styles.clickable)}
+            onClick={handleClickImage}
+          />
+        )}
+        {caption && (
+          <figcaption className={styles.caption}>{caption}</figcaption>
+        )}
+      </span>
+      {showExpandedImage && (
+        <ModalImage setShowExpandedImage={setShowExpandedImage} {...props} />
       )}
-      {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
-    </span>
+    </>
   );
 };
 

--- a/components/MDX/Image.tsx
+++ b/components/MDX/Image.tsx
@@ -68,24 +68,25 @@ export const Image = ({
       setShowExpandedImage(true);
     }
   };
+  const PlainImage = () => {
+    if (shouldExpand) {
+      return (
+        <button onClick={handleClickImage} className={styles.clickable}>
+          <NextImage {...props} className={styles.image} />
+        </button>
+      );
+    } else return <NextImage {...props} className={styles.image} />;
+  };
 
   return (
     <>
       <span className={cn(styles.wrapper, styles[align])}>
         {bordered ? (
           <span className={styles.border}>
-            <NextImage
-              {...props}
-              className={cn(styles.image, shouldExpand && styles.clickable)}
-              onClick={handleClickImage}
-            />
+            <PlainImage />
           </span>
         ) : (
-          <NextImage
-            {...props}
-            className={cn(styles.image, shouldExpand && styles.clickable)}
-            onClick={handleClickImage}
-          />
+          <PlainImage />
         )}
         {caption && (
           <figcaption className={styles.caption}>{caption}</figcaption>

--- a/components/MDX/Image.tsx
+++ b/components/MDX/Image.tsx
@@ -11,7 +11,7 @@ import {
 import NextImage, { ImageProps as NextImageProps } from "next/image";
 import styles from "./Image.module.css";
 import {
-  useClickOutside,
+  useClickInside,
   useEscape,
   useDisableBodyScroll,
 } from "server/custom-hooks";
@@ -40,16 +40,16 @@ const ModalImage = ({ setShowExpandedImage, ...props }: ModalImageProps) => {
     [setShowExpandedImage]
   );
   const modalRef = useRef<HTMLDivElement>();
-  useClickOutside(modalRef, closeHandler);
+  useClickInside(modalRef, closeHandler);
   useEscape(closeHandler);
 
   return (
-    <>
+    <div ref={modalRef}>
       <div className={styles.overlay} />
-      <div className={styles.modal} ref={modalRef}>
+      <div className={styles.dialog}>
         <NextImage className={styles.image} {...props} />
       </div>
-    </>
+    </div>
   );
 };
 
@@ -71,7 +71,7 @@ export const Image = ({
   const PlainImage = () => {
     if (shouldExpand) {
       return (
-        <button onClick={handleClickImage} className={styles.clickable}>
+        <button onClick={handleClickImage} className={styles.zoomable}>
           <NextImage {...props} className={styles.image} />
         </button>
       );

--- a/server/custom-hooks.ts
+++ b/server/custom-hooks.ts
@@ -1,12 +1,11 @@
 import { useEffect } from "react";
 
-export function useClickOutside(ref, handler) {
+export function useClickInside(ref, handler) {
   useEffect(() => {
     const listener = (e: MouseEvent) => {
-      if (!ref.current || ref.current.contains(e.target)) {
-        return;
+      if (ref.current) {
+        handler(e);
       }
-      handler(e);
     };
     document.addEventListener("mousedown", listener);
     return () => {

--- a/server/custom-hooks.ts
+++ b/server/custom-hooks.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+export function useClickOutside(ref, handler) {
+  useEffect(() => {
+    const listener = (e: MouseEvent) => {
+      if (!ref.current || ref.current.contains(e.target)) {
+        return;
+      }
+      handler(e);
+    };
+    document.addEventListener("mousedown", listener);
+    return () => {
+      document.removeEventListener("mousedown", listener);
+    };
+  }, [ref, handler]);
+}
+
+export function useEscape(handler) {
+  useEffect(() => {
+    const listener = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handler(e);
+      }
+    };
+    document.addEventListener("keydown", listener);
+    return () => {
+      document.removeEventListener("keydown", listener);
+    };
+  }, [handler]);
+}
+
+export function useDisableBodyScroll(shouldDisable) {
+  useEffect(() => {
+    if (shouldDisable) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+  }, [shouldDisable]);
+}


### PR DESCRIPTION
Solves Issue https://github.com/gravitational/docs/issues/158.
- It enables most part of docs images to pop-up by clicking on them;
- If the original image's size is small and it doesn't take the maximum width of the content block, pop up feature will be disabled automatically;
- Or, if we specify in the `mdx` file inside the `Image`/`Figure` component a new prop `noPopUp`, it will be also disabled – in case there will be a need to customize this feature for some big images;
- Supported accessibility: selecting on page, opening an expanded image, closing it with keyboard navigation;
- Supported adaptive layout for all kinds of devices. I tested it on a big laptop, small laptop, tablet, and mobile, as well as in dev tools;
- Between different UX solutions, I propose the next one: show `zoom-in` cursor when hovering over the image that can be expanded; and when the image is expanded, then the cursor changes to `zoom-out`. The next click will shrink the image back. This process is shown in the videos below;
- Also, tested it on different browsers: Safari, Google Chrome, Mozilla Firefox, no problems with it.

This video of `goteleport.com/docs/desktop-access/getting-started` shows the feature in general:

https://github.com/gravitational/docs/assets/78731462/a3b302a0-eb8e-436d-91ca-85550390a348

This video shows which images the extension feature is automatically disabled for because it's pointless, and for which it is enabled:

https://github.com/gravitational/docs/assets/78731462/82d832bf-cf3c-4fe1-8c9a-d1277b90dadd

This video shows how the picture in the dialog adapts to any screen size:

https://github.com/gravitational/docs/assets/78731462/df5e31f7-22b3-44eb-8770-6078eec6306d

This video shows the selecting, opening, and closing images in a modal using keyboard navigation by `Tab`, `Shift+Tab`, `Enter`, and `Escape`:

https://github.com/gravitational/docs/assets/78731462/71ffc7cc-e9d2-449e-87ca-b5b47aa02866
