### PR TITLE
Update DocsPage.tsx to fix `latest` link

### DIFF
--- a/layouts/DocsPage/DocsPage.tsx
+++ b/layouts/DocsPage/DocsPage.tsx
@@ -118,7 +118,7 @@ const DocsPage = ({
                   {isBetaVersion && (
                     <>
                       This chapter covers an upcoming release: {current}. We
-                      recommend the <Link href={`/docs${path}`}>latest</Link>{" "}
+                      recommend the <Link href={`${path}`}>latest</Link>{" "}
                       version instead.
                     </>
                   )}


### PR DESCRIPTION
Currently when viewing older docs page, the link to `latest` is broken.  Currently it attempts to link to `/docs/docs`.

It's unclear if `/docs` is the desired path, or if this should be to the current docs page being visited.  But this will at least fix the broken link.