### PR TITLE
Change from default to one: [lint-ordered-list-marker-value one]

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -47,7 +47,7 @@ const configLint = {
     ["lint-list-item-spacing", { checkBlanks: true }],
     ["lint-no-shell-dollars", false],
     ["lint-list-item-indent", "space"],
-    ["lint-ordered-list-marker-value" "one"],
+    ["lint-ordered-list-marker-value", "single"],
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
     [

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -47,7 +47,7 @@ const configLint = {
     ["lint-list-item-spacing", { checkBlanks: true }],
     ["lint-no-shell-dollars", false],
     ["lint-list-item-indent", "space"],
-    "lint-ordered-list-marker-value",
+    ["lint-ordered-list-marker-value" "one"],
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
     [


### PR DESCRIPTION
The linter was throwing warnings for numbered steps like this:
116:1-116:69  warning  Marker should be `3`, was `1`
118:1-120:84  warning  Marker should be `4`, was `1`

That's because the docs engine uses the lint-ordered-list-marker-value plugin ([GitHub](https://github.com/gravitational/docs/blob/79871860893c0c1c66e0d2c60fbaf3e628a0ce50/.remarkrc.mjs#L50C6-L50C36)) to enforce numbering, and the default is ordered (https://www.npmjs.com/package/remark-lint-ordered-list-marker-value#api). 

However, the standard process is to use "1." in Markdown files for auto-numbering. This PR changes this line:
["lint-ordered-list-marker-value", "one"] 

Change to single per the recommendation in the API doc: 
https://www.npmjs.com/package/remark-lint-ordered-list-marker-value#api

Ran `yarn markdown-lint`.
⚠ 656 warnings
Changes made in 14.x are in these PRs:
https://github.com/gravitational/teleport/pull/29143
https://github.com/gravitational/teleport/pull/29094
https://github.com/gravitational/teleport/pull/29093
https://github.com/gravitational/teleport/pull/29086