### PR TITLE
Render TabItems with identical labels correctly

### DIFF
--- a/components/Dropdown/Dropdown.stories.tsx
+++ b/components/Dropdown/Dropdown.stories.tsx
@@ -28,7 +28,7 @@ export const ExpandedDropdown: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     await step("Expand dropdown", async () => {
-      await userEvent.click(canvas.getByText("Version 2"));
+      await userEvent.click(canvas.getByTestId("listbox-input").children[0]);
     });
   },
 };

--- a/components/Dropdown/Dropdown.tsx
+++ b/components/Dropdown/Dropdown.tsx
@@ -48,6 +48,7 @@ export function Dropdown<T>({
       onChange={onChange}
       disabled={disabled}
       className={cn(styles.input, bgColor && styles[bgColor], className)}
+      data-testid={"listbox-input"}
     >
       <ListboxButton
         arrow={icon}
@@ -55,7 +56,9 @@ export function Dropdown<T>({
       >
         {renderOption(value ? pickOption(options, value) : options[0])}
       </ListboxButton>
-      <ListboxPopover className={styles.popover}>
+      {/* Disable the Reach UI portal to enable testing of the component in
+      Storybook*/}
+      <ListboxPopover portal={false} className={styles.popover}>
         <ListboxList>
           {options.map((option) => {
             const id = pickId(option);

--- a/components/Tabs/TabItem.tsx
+++ b/components/Tabs/TabItem.tsx
@@ -3,7 +3,30 @@ import { TabItemProps, TabItemsListProps } from "./types";
 import styles from "./TabItem.module.css";
 
 export const TabItem = ({ children }: TabItemProps) => {
-  return <div className={styles.item}>{children}</div>;
+  return (
+    <div data-testid="tabitem" className={styles.item}>
+      {children}
+    </div>
+  );
+};
+
+/* optionSelected indicates whether one of the dropdown options available for a
+ * TabItem is currently selected.
+ * @param allOptions The value of the "options" prop in a TabItem
+ * @param selectedOption The currently selected option in the Tabs dropdown menu
+ */
+const optionSelected = function (
+  allOptions: string,
+  selectedOption: string
+): boolean {
+  if (!allOptions || !selectedOption) {
+    return true;
+  }
+  const options = allOptions.split(",");
+  if (options.length == 0) {
+    return true;
+  }
+  return options.indexOf(selectedOption) != -1;
 };
 
 export const TabItemList = ({
@@ -11,12 +34,19 @@ export const TabItemList = ({
   currentTab,
   latestDocVers,
   currentDocVers,
+  selectedOption,
 }: TabItemsListProps) => {
   const tabItems = childTabs.map((tab) => {
-    const labeClassName = tab.props.label !== currentTab ? styles.hidden : null;
+    // Mark a tab item as hidden unless its label and one of its dropdown
+    // options are selected.
+    const labeClassName =
+      tab.props.label !== currentTab ||
+      !optionSelected(tab.props.options, selectedOption)
+        ? styles.hidden
+        : null;
 
     return (
-      <div key={tab.props.label} className={labeClassName}>
+      <div key={tab.props.label + tab.props.options} className={labeClassName}>
         {tab.props.scope === "cloud" && latestDocVers !== currentDocVers ? (
           <TabItem label={tab.props.label}>
             <VersionWarning />

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -29,7 +29,7 @@ export const InitialStateTab: Story = {
     const canvas = within(canvasElement);
     await step("Should be the text for the selected option", async () => {
       expect(
-        canvas.findByText(
+        await canvas.findByText(
           "Instructions for installing release using shell commands."
         )
       ).toBeTruthy();
@@ -50,10 +50,97 @@ export const ChangeTab: Story = {
       expect(canvas.getByText("Helm")).toBeEnabled();
       await userEvent.click(canvas.getByText("Helm"));
       expect(
-        canvas.findByText(
+        await canvas.findByText(
           "Instructions for installing release using a Helm chart."
         )
       ).toBeTruthy();
     });
+  },
+};
+
+export const TabsWithDropdownView: Story = {
+  render: () => {
+    return (
+      <Tabs dropdownCaption="Platform" dropdownView>
+        <TabItem label="Option 1">Instructions for Option 1.</TabItem>
+        <TabItem label="Option 2">Instructions for Option 2.</TabItem>
+        <TabItem label="Option 3">Instructions for Option 3.</TabItem>
+      </Tabs>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    step("View the initial tab", async () => {
+      expect(await canvas.findByText("Instructions for Option 1.")).not.toBe(
+        null
+      );
+    });
+  },
+};
+
+export const TabsWithDropdownAndIdenticalLabels: Story = {
+  render: () => {
+    return (
+      <Tabs dropdownCaption="Platform">
+        <TabItem options="Kubernetes Option" label="OSS">
+          Kubernetes/OSS
+        </TabItem>
+        <TabItem options="Linux Server Option" label="OSS">
+          Linux Server/OSS
+        </TabItem>
+        <TabItem options="Kubernetes Option" label="Enterprise">
+          Kubernetes/Enterprise
+        </TabItem>
+        <TabItem options="Linux Server Option" label="Enterprise">
+          Linux Server/Enterprise
+        </TabItem>
+      </Tabs>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    step("Switch dropdown tabs", async () => {
+      userEvent.click(canvas.getByTestId("listbox-input"));
+      userEvent.click(await canvas.findByText("Linux Server Option"));
+      const tabs = canvas.getAllByTestId("tabitem");
+      const visibleTabs = tabs.filter((tab) => {
+        return !tab.parentElement.className.includes("hidden");
+      });
+      expect(visibleTabs.length).toBe(1);
+    });
+  },
+};
+
+export const TabsWithDropdownIdenticalLabelsAndMultipleOptionValues: Story = {
+  render: () => {
+    return (
+      <Tabs dropdownCaption="Platform">
+        <TabItem options="Kubernetes Option" label="OSS">
+          Kubernetes/OSS
+        </TabItem>
+        <TabItem options="Linux Server Option" label="OSS">
+          Linux Server/OSS
+        </TabItem>
+        <TabItem options="Kubernetes Option" label="Enterprise">
+          Kubernetes/Enterprise
+        </TabItem>
+        <TabItem options="Linux Server Option" label="Enterprise">
+          Linux Server/Enterprise
+        </TabItem>
+        <TabItem
+          options="Linux Server Option,Kubernetes Option"
+          label="Cloud Label"
+        >
+          Cloud instructions
+        </TabItem>
+      </Tabs>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByText("Cloud Label"));
+    expect(
+      canvas.getByText("Cloud instructions").parentElement.className
+    ).not.toContain("hidden");
   },
 };

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -204,6 +204,7 @@ export const Tabs = ({
         currentTab={currentTab}
         latestDocVers={latest}
         currentDocVers={current}
+        selectedOption={selectedDropdownOption}
       />
     </div>
   );

--- a/components/Tabs/types.ts
+++ b/components/Tabs/types.ts
@@ -31,6 +31,7 @@ export interface TabsProps {
 export interface TabItemsListProps {
   childTabs: React.ReactComponentElement<React.FC<TabItemProps>>[];
   currentTab: string;
+  selectedOption: string;
   latestDocVers: string;
   currentDocVers: string;
 }


### PR DESCRIPTION
Fixes #141

The `TabItemList` component renders a `TabItem` if its label is selected, but does not evaluate whether a `TabItem`'s `options` property is selected. This means that, if two `TabItem`s have different options but identical labels, both `TabItems` will render.

This change edits `TabItemList` to evaluate both a `TabItem`'s `options` and its `label` to determine whether to render it.

In order to get the Storybook tests to work, this also edits the `Dropdown` component to remove the "portal" option from the Reach UI `ListBoxPopover`. This makes the popover available to Storybook.