### PR TITLE
Support default values in the Var component

### DIFF
--- a/components/Snippet/Snippet.stories.tsx
+++ b/components/Snippet/Snippet.stories.tsx
@@ -30,7 +30,7 @@ export const CopyCommandVar: Story = {
         <Command>
           <CommandLine data-content="$ ">
             curl https://
-            <Var name="example.com" isGlobal="false" description="" />
+            <Var name="example.com" isGlobal={false} description="" />
             /v1/webapi/saml/acs/azure-saml
           </CommandLine>
         </Command>
@@ -61,7 +61,7 @@ export const CopyCodeLineVar: Story = {
       <Snippet>
         <CodeLine>
           curl https://
-          <Var name="example.com" isGlobal="false" description="" />
+          <Var name="example.com" isGlobal={false} description="" />
           /v1/webapi/saml/acs/azure-saml
         </CodeLine>
       </Snippet>

--- a/components/Variables/Var.stories.tsx
+++ b/components/Variables/Var.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { waitFor, userEvent, within } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+
+import { Var } from "../Variables/Var";
+import { VarsProvider } from "../Variables/context";
+
+export const SimpleVar = () => <Var name="myvar" initial="myval" />;
+
+const meta: Meta<typeof Var> = {
+  title: "components/Var",
+  component: SimpleVar,
+};
+export default meta;
+type Story = StoryObj<typeof Var>;
+
+export const EnterValueIntoVariable: Story = {
+  render: () => {
+    return (
+      <VarsProvider>
+        <Var name="myvar" />
+      </VarsProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Enter a value", async () => {
+      await userEvent.click(canvas.getByTestId("var-input"));
+      await userEvent.keyboard("newval");
+      // The test should not throw, i.e., the component's value should be
+      // "newval".
+      await canvas.findByDisplayValue("newval");
+    });
+  },
+};
+
+export const ShowDefaultValueWithOneVar: Story = {
+  render: () => {
+    return (
+      <VarsProvider>
+        <Var name="myvar" initial="myval" />
+      </VarsProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Examine the initial value", async () => {
+      canvas.getByDisplayValue("myval");
+    });
+  },
+};
+
+export const ShowDefaultValueWithMultipleVarsAndOneInitial: Story = {
+  render: () => {
+    return (
+      <VarsProvider>
+        <Var name="myvar" initial="val1" />
+        <Var name="myvar" />
+        <Var name="myvar" />
+      </VarsProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Examine the initial values", async () => {
+      await waitFor(() => {
+        const inputs = canvas.getAllByDisplayValue("val1");
+        expect(inputs.length).toBe(3);
+      });
+    });
+  },
+};
+
+// Expecting the last initial value is arbitrary and based on observation. While
+// authors should avoid setting multiple initial values, throwing an exception
+// would only hurt readers when they attempt to load the page.
+export const ShowDefaultValueWithMultipleVarsAndMultipleInitials: Story = {
+  render: () => {
+    return (
+      <VarsProvider>
+        <Var name="myvar" initial="val1" />
+        <Var name="myvar" initial="val2" />
+        <Var name="myvar" />
+      </VarsProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Examine the initial values", async () => {
+      await waitFor(() => {
+        const inputs = canvas.getAllByDisplayValue("val2");
+        expect(inputs.length).toBe(3);
+      });
+    });
+  },
+};

--- a/components/Variables/VarList.tsx
+++ b/components/Variables/VarList.tsx
@@ -13,7 +13,7 @@ export const VarList = () => {
         name={item}
         description={fieldDescriptions[item]}
         needLabel
-        isGlobal="true"
+        isGlobal={true}
       />
     </li>
   ));


### PR DESCRIPTION
Fixes #190

Support default values in the `Var` component that are distinct from the component's `name`. This way, we can have relatively simple `Var` names but more involved default values.

While expanding the `Var` component, I also removed some optimization callbacks that I'm not sure we really need yet in order to simplify the `Var` code, and changes the `isGlobal` prop to a boolean to simplify operations that use it (no docs pages use `isGlobal` yet, so it's safe to make this change).

Also condenses `setField` and `addField` into a single `putField` function, and declares a separate `setInitial` function for the initial value of a given `Var`.