### PR TITLE
Render dropdown popover above code snippets

### DIFF
--- a/components/Dropdown/Dropdown.module.css
+++ b/components/Dropdown/Dropdown.module.css
@@ -70,6 +70,7 @@
   border: none;
   border-radius: var(--r-sm);
   box-shadow: 0 4px 16px rgba(0 0 0 / 24%) !important;
+  z-index: 1000;
 
   &:focus-within {
     outline: none;

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
+import { default as Pre } from "../MDX/Pre";
 
 import { TabItem } from "./TabItem";
 import { Tabs } from "./Tabs";
@@ -142,5 +143,34 @@ export const TabsWithDropdownIdenticalLabelsAndMultipleOptionValues: Story = {
     expect(
       canvas.getByText("Cloud instructions").parentElement.className
     ).not.toContain("hidden");
+  },
+};
+
+// Ensure the dropdown appears above the code snippet
+export const DropdownWithCodeSnippet: Story = {
+  render: () => {
+    return (
+      <Tabs dropdownCaption="Platform" dropdownView>
+        <TabItem label="Option 1">
+          <Pre>
+            <code>
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+              <br />
+            </code>
+          </Pre>
+        </TabItem>
+        <TabItem label="Option 2">Instructions for the second option.</TabItem>
+        <TabItem label="Option 3">Instructions for the third option.</TabItem>
+      </Tabs>
+    );
   },
 };


### PR DESCRIPTION
Fixes #356

The earlier change #349 edited the `Dropdown` component to set `portal` to `false`, preventing the component from creating a separate React root. While this made it easier to test the Dropdown component within Tabs, also caused the component to render below code snippets.

This change edits the CSS `z-index` of the Dropdown popover so it displays above code snippets. It leaves the `portal` prop as `false`.