### PR TITLE
Fix variable assignment in test

### DIFF
--- a/components/Snippet/Snippet.stories.tsx
+++ b/components/Snippet/Snippet.stories.tsx
@@ -63,7 +63,7 @@ export const CopyCommandVarWithOutput: Story = {
         <Command>
           <CommandLine data-content="$ ">
             curl https://
-            <Var name="example.com" isGlobal="false" description="" />
+            <Var name="example.com" isGlobal={false} description="" />
             /v1/webapi/saml/acs/azure-saml
           </CommandLine>
         </Command>


### PR DESCRIPTION
The type of a `Var`'s `isGlobal` prop should be a Boolean, but the value in one test is a string.