### PR TITLE
Register HCL with rehype-highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "date-fns": "^2.27.0",
     "framer-motion": "^10.12.9",
     "graphql": "^16.6.0",
+    "highlightjs-terraform": "https://github.com/highlightjs/highlightjs-terraform#eb1b9661e143a43dff6b58b391128ce5cdad31d4",
     "jsdom": "^22.1.0",
     "next": "13.2.4",
     "posthog-js": "^1.57.2",

--- a/server/markdown-config.ts
+++ b/server/markdown-config.ts
@@ -23,6 +23,7 @@ import rehypeImages from "./rehype-images";
 import { getVersion, getVersionRootPath } from "./docs-helpers";
 import { loadConfig } from "./config-docs";
 import { codeLangs } from "./code-langs";
+import { definer as hcl } from "highlightjs-terraform";
 
 // We move images to `.next/static` because this folder is preserved
 // in the cache on rebuilds. If we place them in `public` folder, they will
@@ -73,6 +74,7 @@ export const transformToAST = async (value: string, vfile: VFile) => {
         bash: ["bsh", "systemd", "code", "powershell"],
         yaml: ["conf", "toml"],
       },
+      languages: { hcl: hcl },
     }) // Adds syntax highlighting
     .use(rehypeMdxToHast)
     .use(rehypeImages, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10756,6 +10756,10 @@ highlight.js@~11.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
   integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
 
+"highlightjs-terraform@https://github.com/highlightjs/highlightjs-terraform#eb1b9661e143a43dff6b58b391128ce5cdad31d4":
+  version "1.0.6"
+  resolved "https://github.com/highlightjs/highlightjs-terraform#eb1b9661e143a43dff6b58b391128ce5cdad31d4"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
Closes #311

Allow syntax highlighting for `hcl` code blocks so we can make our Terraform snippets more readable.

The syntax highlighter the docs engine uses, `rehype-highlight`, relies on `highlightjs`, which supports HCL via the `highlightjs-terraform` library (https://github.com/highlightjs/highlightjs-terraform).

Unfortunately, this library is not available via NPM, and does not have a maintainer. This change pins a specific commit of the library's GitHub repo with the expectation that, since this library hasn't changed in two years, it won't be adding commits any time soon.