### PR TITLE
Run Storybook tests in the main codebase check

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -44,3 +44,5 @@ jobs:
         run: yarn lint-check
       - name: Run uvu tests
         run: yarn uvu-test
+      - name: Build Storybook, serve and run tests
+        run: yarn build-node && yarn storybook:test-ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -48,8 +48,6 @@ jobs:
       env:
         PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
       run: yarn playwright test --shard=${{ matrix.shard }}
-    - name: Build Storybook, serve and run tests
-      run: yarn storybook:test-ci
     - uses: actions/upload-artifact@v2
       if: always()
       with:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook",
-    "storybook:test-ci": "yarn build-storybook --quiet && npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npx http-server storybook-static --port 6006 --silent\" \"npx wait-on tcp:6006 && yarn test-storybook\"",
+    "storybook:test-ci": "yarn build-storybook && npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npx http-server storybook-static --port 6006 --silent\" \"npx wait-on tcp:6006 && yarn test-storybook\"",
     "storybook:test-local": "yarn build-storybook --quiet && npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npx http-server storybook-static --port 6006 --silent\" \"yarn test-storybook\""
   },
   "lint-staged": {


### PR DESCRIPTION
Storybook checks were in the "Playwright Tests" workflow, which tends to fail and isn't required for `gravitational/docs` PRs to be merged.

Adding these checks to the main codebase check, which runs with every `gravitational/docs` push, will make it clearer when a change breaks our frontend components.