### PR TITLE
Render empty lines in example `code` output

### DIFF
--- a/server/fixtures/code-snippet-empty-line.mdx
+++ b/server/fixtures/code-snippet-empty-line.mdx
@@ -1,0 +1,16 @@
+```code
+$ tsh request search --kind node
+Name                                 Hostname    Labels       Resource ID
+------------------------------------ ----------- ------------
+------------------------------------------------------
+b1168402-9340-421a-a344-af66a6675738 iot         test=test
+/teleport.example.com/node/b1168402-9340-421a-a344-af66a6675738
+bbb56211-7b54-4f9e-bee9-b68ea156be5f node        test=test
+/teleport.example.com/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f
+
+To request access to these resources, run
+> tsh request create --resource
+> /teleport.example.com/node/b1168402-9340-421a-a344-af66a6675738 --resource
+> /teleport.example.com/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f \
+>     --reason <request reason>
+```

--- a/server/fixtures/result/code-snippet-empty-line.mdx
+++ b/server/fixtures/result/code-snippet-empty-line.mdx
@@ -1,0 +1,61 @@
+<Snippet>
+  <Command>
+    <CommandLine data-content="$ ">
+      tsh request search --kind node
+    </CommandLine>
+  </Command>
+
+  <CodeLine>
+    Name                                 Hostname    Labels       Resource ID
+  </CodeLine>
+
+  <CodeLine>
+    \------------------------------------ ----------- ------------
+  </CodeLine>
+
+  <CodeLine>
+    \------------------------------------------------------
+  </CodeLine>
+
+  <CodeLine>
+    b1168402-9340-421a-a344-af66a6675738 iot         test=test
+  </CodeLine>
+
+  <CodeLine>
+    /teleport.example.com/node/b1168402-9340-421a-a344-af66a6675738
+  </CodeLine>
+
+  <CodeLine>
+    bbb56211-7b54-4f9e-bee9-b68ea156be5f node        test=test
+  </CodeLine>
+
+  <CodeLine>
+    /teleport.example.com/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f
+  </CodeLine>
+
+  <CodeLine>
+
+  </CodeLine>
+
+  <br />
+
+  <CodeLine>
+    To request access to these resources, run
+  </CodeLine>
+
+  <CodeLine>
+    \> tsh request create --resource
+  </CodeLine>
+
+  <CodeLine>
+    \> /teleport.example.com/node/b1168402-9340-421a-a344-af66a6675738 --resource
+  </CodeLine>
+
+  <CodeLine>
+    \> /teleport.example.com/node/bbb56211-7b54-4f9e-bee9-b68ea156be5f \
+  </CodeLine>
+
+  <CodeLine>
+    \>     --reason <request reason>
+  </CodeLine>
+</Snippet>

--- a/server/remark-code-snippet.ts
+++ b/server/remark-code-snippet.ts
@@ -281,6 +281,17 @@ export default function remarkCodeSnippet({
             }
           } else {
             children.push(getCodeLine(codeLines[i]));
+            // This is an empty code line. Make sure it renders correctly by
+            // pushing a <br> element after it. Otherwise, this becomes an
+            // empty "CodeLine" element that does not display unless we apply
+            // styling that could have unintended effects on other CodeLines.
+            if (codeLines[i] == "") {
+              children.push({
+                type: "mdxJsxFlowElement",
+                name: "br",
+                attributes: [],
+              });
+            }
           }
         }
 

--- a/uvu-tests/remark-code-snippet.test.ts
+++ b/uvu-tests/remark-code-snippet.test.ts
@@ -243,4 +243,23 @@ Suite("Variables in multiline command support", () => {
   assert.equal(result, expected);
 });
 
+Suite.only("Includes empty lines in example command output", () => {
+  const value = readFileSync(
+    resolve("server/fixtures/code-snippet-empty-line.mdx"),
+    "utf-8"
+  );
+
+  const result = transformer({
+    value,
+    path: "/docs/index.mdx",
+  }).toString();
+
+  const expected = readFileSync(
+    resolve("server/fixtures/result/code-snippet-empty-line.mdx"),
+    "utf-8"
+  );
+
+  assert.equal(result, expected);
+});
+
 Suite.run();


### PR DESCRIPTION
Fixes #103

`remark-code-snippet` splits each line in the content of a `code` snippet and produces either a `CommandLine` or a `CodeLine` for each line. If the line is example output (i.e., not a line beginning with `$`), it produces a `CodeLine`. If there is an empty line, `remark-code-snippet` produces a `CodeLine` with no text content, which does not display when the browser renders the `CodeLine`.

To ensure that the `CodeLine` displays properly, this change edits `remark-code-snippet` to push a `<br>` element to the MDX.js AST it creates after the empty `CodeLine`. This does not affect copy/paste, since the copy/paste logic only handles `CodeLine`s.