### PR TITLE
Support `Var`s in syntax-highlighted snippets

### DIFF
--- a/components/MDX/Pre.stories.tsx
+++ b/components/MDX/Pre.stories.tsx
@@ -3,6 +3,7 @@ import { userEvent, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { default as Pre } from "./Pre";
 import { replaceClipboardWithCopyBuffer } from "utils/clipboard";
+import { Var } from "../Variables/Var";
 
 export const SimplePre = () => (
   <Pre>
@@ -37,6 +38,49 @@ type Story = StoryObj<typeof Pre>;
 export const CopySimplePre: Story = {
   render: () => {
     return <SimplePre />;
+  },
+  play: async ({ canvasElement, step }) => {
+    replaceClipboardWithCopyBuffer();
+    const canvas = within(canvasElement);
+
+    await step("Copy the content", async () => {
+      await userEvent.hover(canvas.getByText("value3"));
+      await userEvent.click(canvas.getByTestId("copy-button-all"));
+      expect(navigator.clipboard.readText()).toEqual(
+        `key1: value
+key2: value
+key3:
+ - value
+ - value2
+ - value3`
+      );
+    });
+  },
+};
+
+export const CopyVarInPre: Story = {
+  render: () => {
+    return (
+      <Pre>
+        <code className="hljs language-yaml">
+          <span className="hljs-attr">key1:</span>{" "}
+          <span className="hljs-string">value</span>
+          {"\n"}
+          <span className="hljs-attr">key2:</span> <Var name="value" />
+          {"\n"}
+          <span className="hljs-attr">key3:</span>
+          {"\n "}
+          <span className="hljs-bullet">-</span>{" "}
+          <span className="hljs-string">value</span>
+          {"\n "}
+          <span className="hljs-bullet">-</span>{" "}
+          <span className="hljs-string">value2</span>
+          {"\n "}
+          <span className="hljs-bullet">-</span>{" "}
+          <span className="hljs-string">value3</span>
+        </code>
+      </Pre>
+    );
   },
   play: async ({ canvasElement, step }) => {
     replaceClipboardWithCopyBuffer();

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-dom": "18.2.0",
     "react-use": "^17.3.1",
     "url": "^0.11.0",
+    "uuid": "^9.0.0",
     "which": "^3.0.0"
   },
   "devDependencies": {

--- a/server/fixtures/go-comment-var.mdx
+++ b/server/fixtures/go-comment-var.mdx
@@ -1,0 +1,8 @@
+```go
+// This is a comment about the code below, which contains a 
+// <Var name="myvar" />. This comment also includes another 
+// <Var name="othervar" />. This is the end of the comment.
+func myfunc(attr string) error {
+  return nil
+}
+```

--- a/server/fixtures/hcl-vars.mdx
+++ b/server/fixtures/hcl-vars.mdx
@@ -1,0 +1,11 @@
+Assign <Var name="proxy" initial="teleport.example.com:443" /> to the address of
+your Teleport Proxy Service.
+
+```hcl
+provider "teleport" {
+  # Update addr to point to your Teleport Cloud tenant URL's host:port
+  addr               = "<Var name="proxy" />"
+  identity_file_path = "terraform-identity"
+}
+```
+

--- a/server/fixtures/result/go-comment-var.html
+++ b/server/fixtures/result/go-comment-var.html
@@ -1,0 +1,7 @@
+<pre><code class="hljs language-go"><span class="hljs-comment">// This is a comment about the code below, which contains a </span>
+<span class="hljs-comment">// </span><var name="myvar"></var><span class="hljs-comment">. This comment also includes another </span>
+<span class="hljs-comment">// </span><var name="othervar"></var><span class="hljs-comment">. This is the end of the comment.</span>
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">myfunc</span><span class="hljs-params">(attr <span class="hljs-type">string</span>)</span></span> <span class="hljs-type">error</span> {
+  <span class="hljs-keyword">return</span> <span class="hljs-literal">nil</span>
+}
+</code></pre>

--- a/server/fixtures/result/hcl-vars.html
+++ b/server/fixtures/result/hcl-vars.html
@@ -1,0 +1,8 @@
+<p>Assign <var name="proxy" initial="teleport.example.com:443"></var> to the address of
+your Teleport Proxy Service.</p>
+<pre><code class="hljs language-hcl"><span class="hljs-keyword">provider</span> <span class="hljs-string">"teleport"</span> {
+  <span class="hljs-comment"># Update addr to point to your Teleport Cloud tenant URL's host:port</span>
+  addr               = <span class="hljs-string">"</span><var name="proxy"></var><span class="hljs-string">"</span>
+  identity_file_path = <span class="hljs-string">"terraform-identity"</span>
+}
+</code></pre>

--- a/server/fixtures/result/yaml-comment-vars.html
+++ b/server/fixtures/result/yaml-comment-vars.html
@@ -1,0 +1,9 @@
+<p>Here are variables in a code snippet:</p>
+<pre><code class="hljs language-yaml"><span class="hljs-comment"># This is a comment where you should set some variable values, e.g.,</span>
+<span class="hljs-comment"># </span><var name="value"></var><span class="hljs-comment"> and </span><var name="value2"></var>
+<span class="hljs-attr">key1:</span> <var name="value"></var>
+  <span class="hljs-bullet">-</span> <var name="value2"></var>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">Another</span> <span class="hljs-string">value</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">Another</span> <span class="hljs-string">value</span>
+<span class="hljs-attr">key2:</span> <span class="hljs-string">A</span> <span class="hljs-string">value</span>
+</code></pre>

--- a/server/fixtures/result/yaml-snippet-var.html
+++ b/server/fixtures/result/yaml-snippet-var.html
@@ -1,0 +1,8 @@
+<p>Here is a YAML snippet:</p>
+<pre><code class="hljs language-yaml"><span class="hljs-attr">key1:</span> <var name="value"></var>
+<span class="hljs-attr">key2:</span> <span class="hljs-string">value</span>
+<span class="hljs-attr">key3:</span>
+ <span class="hljs-bullet">-</span> <span class="hljs-string">value</span>
+ <span class="hljs-bullet">-</span> <span class="hljs-string">value2</span>
+ <span class="hljs-bullet">-</span> <span class="hljs-string">value3</span>
+</code></pre>

--- a/server/fixtures/varlist.mdx
+++ b/server/fixtures/varlist.mdx
@@ -1,0 +1,8 @@
+Here is an example of a `VarList`.
+
+```markdown
+<Details title="Page variables" opened>
+<VarList/>
+</Details>
+```
+

--- a/server/fixtures/yaml-comment-vars.mdx
+++ b/server/fixtures/yaml-comment-vars.mdx
@@ -1,0 +1,11 @@
+Here are variables in a code snippet:
+
+```yaml
+# This is a comment where you should set some variable values, e.g.,
+# <Var name="value" /> and <Var name="value2" />
+key1: <Var name="value" />
+  - <Var name="value2" />
+  - Another value
+  - Another value
+key2: A value
+```

--- a/server/fixtures/yaml-snippet-var.mdx
+++ b/server/fixtures/yaml-snippet-var.mdx
@@ -1,0 +1,10 @@
+Here is a YAML snippet:
+
+```yaml
+key1: <Var name="value" />
+key2: value
+key3:
+ - value
+ - value2
+ - value3
+```

--- a/server/markdown-config.ts
+++ b/server/markdown-config.ts
@@ -9,7 +9,6 @@ import { unified } from "unified";
 import remarkMermaid from "./remark-mermaid";
 import rehypeMdxToHast from "./rehype-mdx-to-hast";
 import remarkMDX from "remark-mdx";
-import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGFM from "remark-gfm";
 import remarkIncludes from "./remark-includes";
@@ -24,6 +23,7 @@ import { getVersion, getVersionRootPath } from "./docs-helpers";
 import { loadConfig } from "./config-docs";
 import { codeLangs } from "./code-langs";
 import { definer as hcl } from "highlightjs-terraform";
+import { rehypeVarInHLJS } from "./rehype-hljs-var";
 
 // We move images to `.next/static` because this folder is preserved
 // in the cache on rebuilds. If we place them in `public` folder, they will
@@ -69,7 +69,7 @@ export const transformToAST = async (value: string, vfile: VFile) => {
       ], // passThrough options says transformer which nodes to leave as is
     }) // Transforms remark to rehype
     .use(rehypeSlug) // Add IDs to headers
-    .use(rehypeHighlight, {
+    .use(rehypeVarInHLJS, {
       aliases: {
         bash: ["bsh", "systemd", "code", "powershell"],
         yaml: ["conf", "toml"],

--- a/server/rehype-hljs-var.ts
+++ b/server/rehype-hljs-var.ts
@@ -1,0 +1,170 @@
+import { unified, Transformer } from "unified";
+import type { VFile } from "vfile";
+import type {
+  MdxJsxFlowElement,
+  MdxJsxTextElement,
+  MdxJsxAttribute,
+  MdxJsxAttributeValueExpression,
+} from "mdast-util-mdx-jsx";
+import type { MDXJSEsm } from "mdast-util-mdxjs-esm";
+import type {
+  MDXFlowExpression,
+  MDXTextExpression,
+} from "mdast-util-mdx-expression";
+import rehypeHighlight, {
+  Options as RehypeHighlightOptions,
+} from "rehype-highlight";
+import { visit, CONTINUE, SKIP } from "unist-util-visit";
+import { v4 as uuid } from "uuid";
+import remarkParse from "remark-parse";
+import type { Text, Element, Node, Parent } from "hast";
+import remarkMDX from "remark-mdx";
+
+const makePlaceholder = (): string => {
+  // UUID for uniqueness, but remove hyphens since these are often parsed
+  // as operators or other non-identifier tokens. Make sure the placeholder
+  // begins with a letter so it gets parsed as an identifier.
+  return "var" + uuid().replaceAll("-", "");
+};
+
+const placeholderPattern = "var[a-z0-9]{32}";
+
+export const rehypeVarInHLJS = (
+  options?: RehypeHighlightOptions
+): Transformer => {
+  return (root: Parent, file: VFile) => {
+    const highlighter = rehypeHighlight(options);
+
+    let placeholdersToVars: Record<string, MdxJsxFlowElement> = {};
+
+    // In a code snippet, Var elements are parsed as text. Replace these with
+    // UUID strings to ensure that the parser won't split these up and make
+    // them unrecoverable.
+    visit(root, undefined, (node: Node, index: number, parent: Parent) => {
+      if (
+        node.type === "text" &&
+        parent.hasOwnProperty("tagName") &&
+        (parent as Element).tagName === "code"
+      ) {
+        const varPattern = new RegExp("<Var[^>]+/>", "g");
+        (node as Text).value = (node as Text).value.replace(
+          varPattern,
+          (match) => {
+            const placeholder = makePlaceholder();
+            // Since the Var element was originally text, parse it so we can recover
+            // its properties. The result should be a small HTML AST with a root
+            // node and one child, the Var node.
+            const varElement = unified()
+              .use(remarkParse)
+              .use(remarkMDX)
+              .parse(match);
+            if (
+              varElement.children.length !== 1 ||
+              (varElement.children[0] as MdxJsxFlowElement).name !== "Var"
+            ) {
+              throw new Error(
+                `Problem parsing file ${file.path}: malformed Var element within a code snippet`
+              );
+            }
+
+            placeholdersToVars[placeholder] = varElement
+              .children[0] as MdxJsxFlowElement;
+            return placeholder;
+          }
+        );
+      }
+    });
+
+    // Apply syntax highlighting
+    (highlighter as Function)(root);
+
+    // After syntax highlighting, the content of the code snippet will be a
+    // series of span elements with different "hljs-*" classes. Find the
+    // placeholder UUIDs and replace them with their original Var elements,
+    // inserting these as HTML AST nodes.
+    visit(root, undefined, (node: Node, index: number, parent: Parent) => {
+      const el = node as Element;
+      if (
+        el.type === "element" &&
+        el.tagName === "span" &&
+        el.children.length === 1 &&
+        el.children[0].type === "text"
+      ) {
+        const hljsSpanValue = (el.children[0] as Text).value;
+
+        // This is an hljs span with only the placeholder as its child.
+        // We don't need the span, so replace it with the original Var.
+        if (placeholdersToVars[hljsSpanValue]) {
+          (parent as any).children[index] = placeholdersToVars[hljsSpanValue];
+          return [CONTINUE];
+        }
+
+        const placeholders = Array.from(
+          hljsSpanValue.matchAll(new RegExp(placeholderPattern, "g"))
+        );
+
+        // No placeholders to recover, so there's nothing more to do.
+        if (placeholders.length == 0) {
+          return [CONTINUE];
+        }
+
+        // An hljs span's text includes one or more Vars among other content, so
+        // we need to replace the span with a series of spans separated by
+        // Vars.
+        let lastIndex = 0;
+        let newChildren: Array<MdxJsxFlowElement | Element> = [];
+        // If there is content before the first Var, separate it into a new hljs
+        // span.
+        if (placeholders[0].index > 0) {
+          newChildren.push({
+            tagName: "span",
+            type: "element",
+            properties: el.properties,
+            children: [
+              {
+                type: "text",
+                value: hljsSpanValue.substring(
+                  lastIndex,
+                  placeholders[0].index
+                ),
+              },
+            ],
+          });
+          lastIndex = placeholders[0].index;
+        }
+        placeholders.forEach((ph, i) => {
+          const placeholderValue = ph[0];
+          newChildren.push(placeholdersToVars[placeholderValue]);
+          lastIndex += placeholderValue.length;
+
+          // Check if there is some non-Var text between either (a) this and the
+          // next Var or (b) between this Var and the end of the content. If
+          // so, add another span and advance the last index.
+          let nextIndex = 0;
+          if (i < placeholders.length - 1) {
+            nextIndex = placeholders[i + 1].index;
+          } else if (i == placeholders.length - 1) {
+            nextIndex = hljsSpanValue.length;
+          }
+          if (lastIndex < nextIndex) {
+            newChildren.push({
+              tagName: "span",
+              type: "element",
+              properties: el.properties,
+              children: [
+                {
+                  type: "text",
+                  value: hljsSpanValue.substring(lastIndex, nextIndex),
+                },
+              ],
+            });
+            lastIndex = nextIndex;
+          }
+        });
+        // Delete the current span and replace it with the new children.
+        parent.children.splice(index, 1, ...newChildren);
+        return [SKIP, index + newChildren.length];
+      }
+    });
+  };
+};

--- a/server/rehype-hljs-var.ts
+++ b/server/rehype-hljs-var.ts
@@ -46,7 +46,7 @@ export const rehypeVarInHLJS = (
         parent.hasOwnProperty("tagName") &&
         (parent as Element).tagName === "code"
       ) {
-        const varPattern = new RegExp("<Var[^>]+/>", "g");
+        const varPattern = new RegExp("<Var [^>]+/>", "g");
         (node as Text).value = (node as Text).value.replace(
           varPattern,
           (match) => {

--- a/uvu-tests/rehype-hljs-var.test.ts
+++ b/uvu-tests/rehype-hljs-var.test.ts
@@ -1,0 +1,122 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+
+import rehypeMdxToHast from "../server/rehype-mdx-to-hast";
+import { VFile, VFileOptions } from "vfile";
+import { remark } from "remark";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import mdx from "remark-mdx";
+import { rehypeVarInHLJS } from "../server/rehype-hljs-var";
+import { unified } from "unified";
+import remarkRehype from "remark-rehype";
+import remarkParse from "remark-parse";
+import rehypeStringify from "rehype-stringify";
+import { definer as hcl } from "highlightjs-terraform";
+
+const Suite = suite("server/remark-hljs-var");
+
+const transformer = (options: VFileOptions) =>
+  // TODO: The configuration below includes a subset of the processors found in
+  // transformToAST (server/markdown-config.ts). Extract this into a separate
+  // function to avoid drift in how we use rehype.
+  unified()
+    .use(remarkParse)
+    .use(mdx)
+    .use(remarkRehype, {
+      passThrough: [
+        "mdxFlowExpression",
+        "mdxJsxFlowElement",
+        "mdxJsxTextElement",
+        "mdxTextExpression",
+        "mdxjsEsm",
+      ], // passThrough options says transformer which nodes to leave as is
+    }) // Transforms remark to rehype
+    .use(rehypeVarInHLJS, {
+      languages: { hcl: hcl },
+    })
+    .use(rehypeMdxToHast)
+    // rehypeStringify is not used in transformToAST. We use it to generate
+    // human-readable test output.
+    .use(rehypeStringify)
+    .processSync(new VFile(options));
+
+Suite("Insert Var components as HTML nodes: Var gets its own hljs span", () => {
+  const result = transformer({
+    value: readFileSync(
+      resolve("server/fixtures/yaml-snippet-var.mdx"),
+      "utf-8"
+    ),
+    path: "/docs/index.mdx",
+  });
+
+  // Note that, because of rehypeMdxToHast, the <Var> components ending up
+  // having the <var> tag. The MDX configuration in the DocsPage layout maps
+  // this to Var.
+  assert.equal(
+    (result.value as string).trim(),
+    readFileSync(
+      resolve("server/fixtures/result/yaml-snippet-var.html"),
+      "utf-8"
+    ).trim()
+  );
+});
+
+Suite(
+  "Insert Var components as HTML nodes: Var part of a broader span in go",
+  () => {
+    const result = transformer({
+      value: readFileSync(
+        resolve("server/fixtures/go-comment-var.mdx"),
+        "utf-8"
+      ),
+      path: "/docs/index.mdx",
+    });
+
+    assert.equal(
+      (result.value as string).trim(),
+      readFileSync(
+        resolve("server/fixtures/result/go-comment-var.html"),
+        "utf-8"
+      ).trim()
+    );
+  }
+);
+
+Suite(
+  "Insert Var components as HTML nodes: Var part of a broader span in YAML",
+  () => {
+    const result = transformer({
+      value: readFileSync(
+        resolve("server/fixtures/yaml-comment-vars.mdx"),
+        "utf-8"
+      ),
+      path: "/docs/index.mdx",
+    });
+
+    assert.equal(
+      (result.value as string).trim(),
+      readFileSync(
+        resolve("server/fixtures/result/yaml-comment-vars.html"),
+        "utf-8"
+      ).trim()
+    );
+  }
+);
+
+Suite("Insert Var components as HTML nodes: text after a Var", () => {
+  const result = transformer({
+    value: readFileSync(resolve("server/fixtures/hcl-vars.mdx"), "utf-8"),
+    path: "/docs/index.mdx",
+  });
+
+  assert.equal(
+    (result.value as string).trim(),
+    readFileSync(
+      resolve("server/fixtures/result/hcl-vars.html"),
+      "utf-8"
+    ).trim()
+  );
+});
+
+Suite.run();

--- a/uvu-tests/rehype-hljs-var.test.ts
+++ b/uvu-tests/rehype-hljs-var.test.ts
@@ -119,4 +119,12 @@ Suite("Insert Var components as HTML nodes: text after a Var", () => {
   );
 });
 
+Suite("Ignore VarList in code snippet components", () => {
+  // This throws if the plugin interprets VarList components as being Vars.
+  transformer({
+    value: readFileSync(resolve("server/fixtures/varlist.mdx"), "utf-8"),
+    path: "/docs/index.mdx",
+  });
+});
+
 Suite.run();


### PR DESCRIPTION
Fixes #186

Syntax highlighting in the docs engine works by using `rehype-highlight`, which is a wrapper for `highlight.js`. `highlight.js` applies syntax highlighting by replacing the contents of a `<pre><code></code></pre>` with `<span>` elements that include `hljs-*` class names.

The way `highlight.js` works poses difficulties for adding `Var` components to syntax-highlighted code snippets, since any content within a code snippet becomes subject to rewrites by `highlight.js`.

Without access to the `highlight.js` internals, we need to:

- Support a consistent `Var` experience inside and outside code snippets
- Prevent `Var`s from being overwritten

This change presents a solution that:

- Replaces `Var` components with UUIDs: This minimizes the chance that a `Var` component will be highlighted, since characters in `[a-z0-9]` are usually permissible within strings or identifiers. This also removes hyphens and begins the placeholder with a letter to help ensure the highlighter parses it as an identifier.
- Maintains a map of placeholder strings to AST nodes.
- After applying syntax highlighting to a page, replaces the placeholder strings with the corresponding AST node.