### PR TITLE
Add workflow to deploy vercel preview

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -1,0 +1,38 @@
+name: Deploy Vercel Preview
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  pull_request: 
+    types: [ opened, reopened, edited, synchronize ]
+  workflow_dispatch:
+
+jobs:
+  deploy-vercel-preview:
+    name: Deploy vercel preview
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: yarn global add vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > deployment-url.txt
+          preview_url="$(cat deployment-url.txt)"
+          echo "PREVIEW_URL=$preview_url" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🤖 Vercel Preview Here: ${{ steps.deploy.outputs.PREVIEW_URL }} '
+            })


### PR DESCRIPTION
Add github actions workflow to deploy a vercel preview when new PR's are opened or updated. A githubActions bot user will then comment the url of the preview deployment to allow faster docs review.