### PR TITLE
Fix the "Lint code base" workflow and package.json

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -9,38 +9,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache yarn cache
-        uses: actions/cache@v3.0.7
-        id: cache-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-yarn-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-            ${{ runner.os }}-${{ steps.nvm.ouputs.NVMRC }}-nodemodules-
+          node-version: "18"
       - run: yarn
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Check TypeScript integrity
         run: yarn typecheck
       - name: Check .js and .ts code
         run: yarn lint-check
       - name: Run uvu tests
         run: yarn uvu-test
+      - name: Attempt to build the docs
+        run: yarn update-and-build

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,5 +1,16 @@
 name: CI
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  merge_group:
+    types:
+      - checks_requested
 jobs:
   lint-code-base:
     name: Lint code base

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "teleport-docs-next",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "engine": {
-    "node": ">=18.0.0"
+  "engines": {
+    "node": "^18"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fix the "Lint code base" workflow and package.json

This change cleans up the "Lint code base" GitHub Actions workflow in
order to ensure that it works as expected:

- Change `node-version` to 18 to match Vercel as well as the
  `gravitational/teleport` GitHub Actions runner.
- Build the docs to add an extra layer of protection against faulty docs
  changes making it to Vercel
- Remove cacheing logic. `gravitational/docs` PRs aren't frequent enough
  to warrant a cache for node_modules and yarn state, and often need to
  change dependencies anyway. Removing this takes away unneeded
  complexity.  Also worth noting that the cacheing logic referred to an
  `nvm` step that isn't executed in this job.

This change also fixes the "engines" key in `package.json`. This was
previously given as "engine", which is not a valid `package.json` key.
Also constrains the Node version to minor/patch releases of v18.
