### PR TITLE
Switch `TabItem`s with identical labels together

### DIFF
--- a/components/Tabs/TabContext.tsx
+++ b/components/Tabs/TabContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useState } from "react";
+import { createHash } from "crypto";
+import type { BinaryToTextEncoding } from "crypto";
+import { DataTab } from "./types";
+import type { ReactNode } from "react";
+
+export interface TabContextProps {
+  getSelectedLabel: (tabs: Array<string>) => string;
+  setSelectedLabel: (tabs: Array<string>, selected: string) => void;
+}
+
+export const TabContext = createContext<TabContextProps>({
+  getSelectedLabel: (tabs: Array<string>): string => {
+    return "";
+  },
+  setSelectedLabel: (tabs: Array<string>, selected: string) => {
+    return;
+  },
+});
+
+const labelHashKey = (labels: Array<string>): string => {
+  const labelsCopy = [...labels];
+  labelsCopy.sort();
+  const hash = createHash("sha256");
+  hash.update(labelsCopy.join(""));
+  return hash.digest("utf8" as BinaryToTextEncoding);
+};
+
+interface TabContextProviderProps {
+  children: ReactNode;
+}
+
+export const TabContextProvider = ({ children }: TabContextProviderProps) => {
+  const [stateForAllLabels, setStateForAllLabels] = useState({});
+
+  const context = {
+    getSelectedLabel: (tabs: Array<string>): string => {
+      return stateForAllLabels[labelHashKey(tabs)];
+    },
+
+    setSelectedLabel: (tabs: Array<string>, selected: string): void => {
+      const key = labelHashKey(tabs);
+      setStateForAllLabels((prevState) => {
+        return { ...prevState, [key]: selected };
+      });
+    },
+  };
+
+  return <TabContext.Provider value={context}>{children}</TabContext.Provider>;
+};

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -2,20 +2,24 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { default as Pre } from "../MDX/Pre";
+import { TabContextProvider } from "./TabContext";
+import { DocsContextProvider } from "layouts/DocsPage/context";
 
 import { TabItem } from "./TabItem";
 import { Tabs } from "./Tabs";
 
 export const DefaultTabsWithSelected = () => (
-  <Tabs>
-    <TabItem label="Source">Instructions for building from source.</TabItem>
-    <TabItem label="Helm">
-      Instructions for installing release using a Helm chart.
-    </TabItem>
-    <TabItem label="Shell" selected>
-      Instructions for installing release using shell commands.
-    </TabItem>
-  </Tabs>
+  <TabContextProvider>
+    <Tabs>
+      <TabItem label="Source">Instructions for building from source.</TabItem>
+      <TabItem label="Helm">
+        Instructions for installing release using a Helm chart.
+      </TabItem>
+      <TabItem label="Shell" selected>
+        Instructions for installing release using shell commands.
+      </TabItem>
+    </Tabs>
+  </TabContextProvider>
 );
 
 const meta: Meta<typeof Tabs> = {
@@ -62,11 +66,13 @@ export const ChangeTab: Story = {
 export const TabsWithDropdownView: Story = {
   render: () => {
     return (
-      <Tabs dropdownCaption="Platform" dropdownView>
-        <TabItem label="Option 1">Instructions for Option 1.</TabItem>
-        <TabItem label="Option 2">Instructions for Option 2.</TabItem>
-        <TabItem label="Option 3">Instructions for Option 3.</TabItem>
-      </Tabs>
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform" dropdownView>
+          <TabItem label="Option 1">Instructions for Option 1.</TabItem>
+          <TabItem label="Option 2">Instructions for Option 2.</TabItem>
+          <TabItem label="Option 3">Instructions for Option 3.</TabItem>
+        </Tabs>
+      </TabContextProvider>
     );
   },
   play: async ({ canvasElement, step }) => {
@@ -82,27 +88,29 @@ export const TabsWithDropdownView: Story = {
 export const TabsWithDropdownAndIdenticalLabels: Story = {
   render: () => {
     return (
-      <Tabs dropdownCaption="Platform">
-        <TabItem options="Kubernetes Option" label="OSS">
-          Kubernetes/OSS
-        </TabItem>
-        <TabItem options="Linux Server Option" label="OSS">
-          Linux Server/OSS
-        </TabItem>
-        <TabItem options="Kubernetes Option" label="Enterprise">
-          Kubernetes/Enterprise
-        </TabItem>
-        <TabItem options="Linux Server Option" label="Enterprise">
-          Linux Server/Enterprise
-        </TabItem>
-      </Tabs>
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform">
+          <TabItem options="Kubernetes Option" label="OSS">
+            Kubernetes/OSS
+          </TabItem>
+          <TabItem options="Linux Server Option" label="OSS">
+            Linux Server/OSS
+          </TabItem>
+          <TabItem options="Kubernetes Option" label="Enterprise">
+            Kubernetes/Enterprise
+          </TabItem>
+          <TabItem options="Linux Server Option" label="Enterprise">
+            Linux Server/Enterprise
+          </TabItem>
+        </Tabs>
+      </TabContextProvider>
     );
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     step("Switch dropdown tabs", async () => {
-      userEvent.click(canvas.getByTestId("listbox-input"));
-      userEvent.click(await canvas.findByText("Linux Server Option"));
+      await userEvent.click(canvas.getByTestId("listbox-input"));
+      await userEvent.click(await canvas.findByText("Linux Server Option"));
       const tabs = canvas.getAllByTestId("tabitem");
       const visibleTabs = tabs.filter((tab) => {
         return !tab.parentElement.className.includes("hidden");
@@ -115,26 +123,28 @@ export const TabsWithDropdownAndIdenticalLabels: Story = {
 export const TabsWithDropdownIdenticalLabelsAndMultipleOptionValues: Story = {
   render: () => {
     return (
-      <Tabs dropdownCaption="Platform">
-        <TabItem options="Kubernetes Option" label="OSS">
-          Kubernetes/OSS
-        </TabItem>
-        <TabItem options="Linux Server Option" label="OSS">
-          Linux Server/OSS
-        </TabItem>
-        <TabItem options="Kubernetes Option" label="Enterprise">
-          Kubernetes/Enterprise
-        </TabItem>
-        <TabItem options="Linux Server Option" label="Enterprise">
-          Linux Server/Enterprise
-        </TabItem>
-        <TabItem
-          options="Linux Server Option,Kubernetes Option"
-          label="Cloud Label"
-        >
-          Cloud instructions
-        </TabItem>
-      </Tabs>
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform">
+          <TabItem options="Kubernetes Option" label="OSS">
+            Kubernetes/OSS
+          </TabItem>
+          <TabItem options="Linux Server Option" label="OSS">
+            Linux Server/OSS
+          </TabItem>
+          <TabItem options="Kubernetes Option" label="Enterprise">
+            Kubernetes/Enterprise
+          </TabItem>
+          <TabItem options="Linux Server Option" label="Enterprise">
+            Linux Server/Enterprise
+          </TabItem>
+          <TabItem
+            options="Linux Server Option,Kubernetes Option"
+            label="Cloud Label"
+          >
+            Cloud instructions
+          </TabItem>
+        </Tabs>
+      </TabContextProvider>
     );
   },
   play: async ({ canvasElement, step }) => {
@@ -150,27 +160,161 @@ export const TabsWithDropdownIdenticalLabelsAndMultipleOptionValues: Story = {
 export const DropdownWithCodeSnippet: Story = {
   render: () => {
     return (
-      <Tabs dropdownCaption="Platform" dropdownView>
-        <TabItem label="Option 1">
-          <Pre>
-            <code>
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-              <br />
-            </code>
-          </Pre>
-        </TabItem>
-        <TabItem label="Option 2">Instructions for the second option.</TabItem>
-        <TabItem label="Option 3">Instructions for the third option.</TabItem>
-      </Tabs>
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform" dropdownView>
+          <TabItem label="Option 1">
+            <Pre>
+              <code>
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+                <br />
+              </code>
+            </Pre>
+          </TabItem>
+          <TabItem label="Option 2">
+            Instructions for the second option.
+          </TabItem>
+          <TabItem label="Option 3">Instructions for the third option.</TabItem>
+        </Tabs>
+      </TabContextProvider>
     );
+  },
+};
+
+export const TabItemsWithTheSameLabelsChangeTogether: Story = {
+  render: () => {
+    return (
+      <DocsContextProvider>
+        <TabContextProvider>
+          <Tabs>
+            <TabItem label="Kubernetes Label">
+              Initial Kubernetes instructions
+            </TabItem>
+            <TabItem label="Linux VM Label">
+              Initial Linux VM instructions.
+            </TabItem>
+            <TabItem label="Another Platform Label">
+              Instructions for another platform.
+            </TabItem>
+          </Tabs>
+          <Tabs>
+            <TabItem label="Self-Hosted">Self-Hosted instructions</TabItem>
+            <TabItem label="Linux VM Label">
+              These instructions should remain hidden.
+            </TabItem>
+            <TabItem label="Cloud Label">Cloud instructions</TabItem>
+          </Tabs>
+          <Tabs>
+            <TabItem label="Kubernetes Label">
+              More Kubernetes instructions
+            </TabItem>
+            <TabItem label="Another Platform Label">
+              Instructions for another platform.
+            </TabItem>
+            <TabItem label="Linux VM Label">More Linux VM instructions</TabItem>
+          </Tabs>
+        </TabContextProvider>
+      </DocsContextProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const linuxLabels = canvas.getAllByText("Linux VM Label");
+    await userEvent.click(linuxLabels[0]);
+    expect(
+      canvas.getByText("More Linux VM instructions").parentElement.className
+    ).not.toContain("hidden");
+    expect(
+      canvas.getByText("These instructions should remain hidden.").parentElement
+        .className
+    ).toContain("hidden");
+  },
+};
+
+export const TabsWithIdenticalDropdownsChangeTogether: Story = {
+  render: () => {
+    return (
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform">
+          <TabItem options="Kubernetes Option" label="OSS">
+            Kubernetes/OSS
+          </TabItem>
+          <TabItem options="Linux Server Option" label="OSS">
+            Linux Server/OSS
+          </TabItem>
+          <TabItem options="Kubernetes Option" label="Enterprise label">
+            Kubernetes/Enterprise
+          </TabItem>
+          <TabItem options="Linux Server Option" label="Enterprise label">
+            Linux Server/Enterprise
+          </TabItem>
+        </Tabs>
+
+        <Tabs dropdownCaption="Platform">
+          <TabItem options="Kubernetes Option" label="OSS">
+            Kubernetes/OSS 2
+          </TabItem>
+          <TabItem options="Linux Server Option" label="OSS">
+            Linux Server/OSS 2
+          </TabItem>
+          <TabItem options="Kubernetes Option" label="Enterprise label">
+            Kubernetes/Enterprise 2
+          </TabItem>
+          <TabItem options="Linux Server Option" label="Enterprise label">
+            Linux Server/Enterprise 2
+          </TabItem>
+        </Tabs>
+      </TabContextProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const ents = canvas.getAllByText("Enterprise label");
+    await userEvent.click(ents[0]);
+    const dropdowns = canvas.getAllByTestId("listbox-input");
+    await userEvent.click(dropdowns[0].children[0]);
+    const linuxOptions = await canvas.findAllByText("Linux Server Option");
+    await userEvent.click(linuxOptions[0]);
+
+    expect(
+      canvas.getByText("Linux Server/Enterprise 2").parentElement.className
+    ).not.toContain("hidden");
+  },
+};
+
+export const TabsWithDropdownViewChangeTogether: Story = {
+  render: () => {
+    return (
+      <TabContextProvider>
+        <Tabs dropdownCaption="Platform" dropdownView>
+          <TabItem label="Option 1">First instructions for Option 1.</TabItem>
+          <TabItem label="Option 2">First instructions for Option 2.</TabItem>
+        </Tabs>
+        <Tabs dropdownCaption="Platform" dropdownView>
+          <TabItem label="Option 1">Second instructions for Option 1.</TabItem>
+          <TabItem label="Option 2">Second instructions for Option 2.</TabItem>
+        </Tabs>
+      </TabContextProvider>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const dropdowns = canvas.getAllByTestId("listbox-input");
+    await userEvent.click(dropdowns[0].children[0]);
+    const options = await canvas.findAllByText("Option 2");
+    await userEvent.click(options[0]);
+
+    expect(
+      canvas.getByText("Second instructions for Option 2.").parentElement
+        .className
+    ).not.toContain("hidden");
   },
 };

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -4,7 +4,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useState,
 } from "react";
 import { Dropdown } from "components/Dropdown";
 import { DocsContext, getScopes } from "layouts/DocsPage/context";
@@ -12,6 +11,7 @@ import { TabLabelList } from "./TabLabel";
 import { TabItemList } from "./TabItem";
 import { DataTab, TabsInDropdowns, TabItemProps, TabsProps } from "./types";
 import styles from "./Tabs.module.css";
+import { TabContext } from "./TabContext";
 
 /**
  * An example of using this component.
@@ -67,11 +67,6 @@ const isInDropdown = (options: string, dropdownSelected: string): boolean => {
   return getDropdownFromItem(options).includes(dropdownSelected);
 };
 
-const getSelectedTab = (tabsMeta: DataTab[]) => {
-  const selected = tabsMeta.find((t) => t.isPreSelected);
-  return selected ? selected.label : tabsMeta[0].label;
-};
-
 // this option is added to unify the code.
 // It is needed to display tabs correctly if there is no dropdown
 const DEFAULT_DROPDOWN = "$all";
@@ -86,6 +81,23 @@ export const Tabs = ({
     scope,
     versions: { latest, current },
   } = useContext(DocsContext);
+
+  const { getSelectedLabel, setSelectedLabel } = useContext(TabContext);
+
+  const getSelectedTab = (tabsMeta: DataTab[]) => {
+    const labels = tabsMeta.map((t) => t.label);
+    const previousLabel = getSelectedLabel(labels);
+    if (previousLabel) {
+      return previousLabel;
+    }
+    const selected = tabsMeta.find((t) => t.isPreSelected);
+    return selected ? selected.label : tabsMeta[0].label;
+  };
+
+  const getSelectedDropdownOption = (options: Array<string>) => {
+    const prevLabel = getSelectedLabel(options);
+    return prevLabel ? prevLabel : options[0];
+  };
 
   const childTabs = useMemo(
     () =>
@@ -133,11 +145,19 @@ export const Tabs = ({
     return data;
   }, [childTabs, dropdownVarsArr]);
 
-  const [selectedDropdownOption, setSelectedDropdownOpt] = useState(
-    dropdownSelected ? dropdownSelected : dropdownVarsArr[0]
-  );
+  const selectedDropdownOption = getSelectedDropdownOption(dropdownVarsArr);
   const tabsMeta = tabsInDropdown[selectedDropdownOption];
-  const [currentTab, setCurrentTab] = useState(getSelectedTab(tabsMeta));
+  const currentTab = getSelectedTab(tabsMeta);
+  const setCurrentTab = (label: string) => {
+    setSelectedLabel(
+      tabsMeta.map((t) => t.label),
+      label
+    );
+  };
+
+  const setSelectedDropdownOpt = (option: string) => {
+    setSelectedLabel(dropdownVarsArr, option);
+  };
 
   /* selectedDropdownOption is needed here.
    * We have to change the selected tab when we change a dropdown option

--- a/components/Tabs/index.ts
+++ b/components/Tabs/index.ts
@@ -1,3 +1,4 @@
 export { Tabs } from "./Tabs";
 export { TabItem } from "./TabItem";
+export { TabContextProvider } from "./TabContext";
 export type { TabsProps, TabItemProps } from "./types";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import type { AppProps } from "next/app";
 import { DocsContextProvider } from "layouts/DocsPage/context";
 import { posthog, sendPageview } from "utils/posthog";
+import { TabContextProvider } from "components/Tabs";
 
 // https://larsmagnus.co/blog/how-to-optimize-custom-fonts-with-next-font
 // Next Font to enable zero layout shift which is hurting SEO.
@@ -144,7 +145,9 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       `}</style>
       <Analytics />
       <DocsContextProvider>
-        <Component {...pageProps} />
+        <TabContextProvider>
+          <Component {...pageProps} />
+        </TabContextProvider>
       </DocsContextProvider>
     </>
   );


### PR DESCRIPTION
Fixes #317

If multiple `Tabs` components include `TabItem`s with identical labels, when a user switches to a particular `TabItem` within one of these `Tabs` components, switch the other `Tabs` components as well.

This saves a user from clicking the same tabs repeatedly when navigating through the docs site. It also captures most of the usefulness of the scope switcher while being far more visible for users, who tend not to realize that the scope switcher exists. This will make it easier to eventually deprecate the scope switcher.

This change adds a `TabContextProvider` high in the component tree (just below `DocsContextProvider`). `Tabs` components look up their currently selected tab from this context provider, rather than from component-local state. The `TabContextProvider` hashes the sorted label names of a `Tabs` component to get and set the value of the currently selected `TabItem`.

`Tabs` components with a dropdown menu, as well as `Tabs` components in `dropDownView` mode, also use this context provider to find the current value of dropdown menu items.

Note that the `DocsContextProvider`'s scope value currently supersedes the values managed by the `TabContextProvider`. For example, if a `Tabs` component on one page has the "Enterprise" dropdown menu item selected, and the user has the `oss` scope selected, a `Tabs` component with the same dropdown menu on another page will show "Open Source" instead of "Enterprise". We can change this by deprecating the docs scopes.