### PR TITLE
xss filter and url appended

### DIFF
--- a/components/Feedback/Feedback.tsx
+++ b/components/Feedback/Feedback.tsx
@@ -2,6 +2,7 @@ import styles from "./Feedback.module.css";
 import React, { FormEvent, useState } from "react";
 import ButtonPrimary from "components/Button";
 import { sendDocsFeedback } from "utils/posthog";
+import { filterTextForXSS } from "utils/general";
 import Button from "components/Button";
 import Image from "next/image";
 import ThumbsUp from "./thumbs-up.svg";
@@ -45,6 +46,13 @@ export default function PageWithJSbasedForm(props) {
       comment,
       url: window.location.pathname, // This will include the current page URL
     };
+
+    data.comment = filterTextForXSS(data.comment);
+
+    // Appending URL to comment for context due to PostHog viewing limitations
+    if (data.comment !== "") {
+      data.comment += ` (${data.url})`;
+    }
 
     await forwardData(data);
     setIsSubmitted(true);

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -39,3 +39,15 @@ export const getFirstLvlNav = (locPath: string): string => {
 
   return firstLvlNav;
 };
+
+/**
+ * This function is a basic filter for XSS when form text is submitted.
+ * Very simply, it just looks for the opening symbol of a script '<' tag.
+ * If includes, then returns a blank string, otherwise returns the text.
+ */
+export const filterTextForXSS = (text: string): string => {
+  if (text.includes("<")) {
+    return "";
+  }
+  return text;
+};


### PR DESCRIPTION
Two improvements for the Docs Feedback Component
1. We can't get the URL and the Comment both to show in a helpful way in PostHog. Thus this PR will append the url onto the  end of the comment so that we can have context as to what page the comment applies to.
2. We are getting scripts and tags submitted in the form and it isn't helpful to see these in PostHog. Thus a filter was added to keep these from coming through. 