### PR TITLE
Remove inkeep AI chat mode toggle

### DIFF
--- a/components/Search/InkeepSearch.tsx
+++ b/components/Search/InkeepSearch.tsx
@@ -134,16 +134,6 @@ const inkeepAIChatSettings: InkeepAIChatSettings = {
   botAvatarSrcUrl: "https://goteleport.com/static/pam-standing.svg",
   isControlledMessage: true,
   defaultChatMode: "AUTO",
-  toggleButtonSettings: {
-    isChatModeToggleEnabled: true,
-    chatModeToggleValue: "TURBO",
-    chatModeToggleLabel: "Turbo Mode",
-    chatModeToggleTooltip:
-      "Turbo mode provides faster responses but can be less accurate.",
-  },
-  disclaimerSettings: {
-    isDisclaimerEnabled: false,
-  },
 };
 
 const inkeepSearchSettings: InkeepSearchSettings = {


### PR DESCRIPTION
## Purpose

After discussing it with @klizhentas, it was decided that we should remove the toggle that enables `Turbo` mode in the inkeep AI chat. All chat prompts will now use `Expert` mode which is the recommended mode and currently the default.