### PR TITLE
Remove gray background in images

### DIFF
--- a/components/MDX/Image.module.css
+++ b/components/MDX/Image.module.css
@@ -45,6 +45,13 @@
 }
 
 .zoomable {
+  /* 
+   * The background-color and border styles override browser defaults for the
+   * button element.
+   */
+  background-color: inherit;
+  border: inherit;
+
   cursor: zoom-in;
   cursor: -moz-zoom-in; 
   cursor: -webkit-zoom-in;


### PR DESCRIPTION
In df94b23074203819e999ea373db41ed9bf7cc884, we made images clickable to enable them to pop up as a modal. This put images inside a `button` element, which in browsers renders with a gray background and border. This change removes the default background and border.