### PR TITLE
Support anchor-only links within partials

### DIFF
--- a/server/fixtures/includes/anchor-links.mdx
+++ b/server/fixtures/includes/anchor-links.mdx
@@ -1,0 +1,5 @@
+This is a [link to an anchor](#this-is-a-section).
+
+## This is a section.
+
+This is content within the section.

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -287,8 +287,14 @@ const handleURLPath = (
   ) {
     const href = node.url;
 
-    // Ignore non-strings, absolute paths, or web URLs
-    if (typeof href !== "string" || href[0] === "/" || /^http/.test(href)) {
+    // Ignore non-strings, absolute paths, web URLs, and links consisting only
+    // of anchors (these will end up pointing to the containing page).
+    if (
+      typeof href !== "string" ||
+      href[0] === "/" ||
+      /^http/.test(href) ||
+      href[0] === "#"
+    ) {
       return href;
     }
 

--- a/uvu-tests/remark-includes.test.ts
+++ b/uvu-tests/remark-includes.test.ts
@@ -590,4 +590,30 @@ boundary" section.
   }
 );
 
+Suite.only(
+  "Interprets anchor-only links correctly when loading partials",
+  () => {
+    const actual = transformer({
+      value: `Here is the outer page.
+
+(!anchor-links.mdx!)
+
+`,
+      path: "server/fixtures/mypage.mdx",
+    }).toString();
+
+    assert.equal(
+      actual,
+      `Here is the outer page.
+
+This is a [link to an anchor](#this-is-a-section).
+
+## This is a section.
+
+This is content within the section.
+`
+    );
+  }
+);
+
 Suite.run();


### PR DESCRIPTION
Let's say a partial includes a link like this:

```markdown
[Link text](#anchor)
```

The link will render like this, which is incorrect:

```markdown
[Link text](includes/#anchor)
```

This is because of the way `remark-includes` processes relative links in partials.

Some partials need to link to an anchor within the same page. This change supports this by ignoring links with references that begin with `#`. Since all headings are flattened into the containing page, we can safely ignore file paths for anchor links.