### PR TITLE
Add access graph link to nav

### DIFF
--- a/components/Menu/structure.ts
+++ b/components/Menu/structure.ts
@@ -37,6 +37,10 @@ const menu: MenuCategoryProps[] = [
         href: "/features/",
         titleLink: true,
         children: [
+          {
+            title: "Access Graph",
+            href: "/features/access-graph/",
+          },
           { title: "Assist", href: "/features/assist/" },
           { title: "Single Sign On", href: "/features/sso-for-ssh/" },
           {

--- a/tests/data/navbar-data.ts
+++ b/tests/data/navbar-data.ts
@@ -69,6 +69,11 @@ export const navigationData: NavbarData = [
           isExternal: true,
         },
         { title: "Our Features", href: "/features/", isExternal: true },
+        {
+          title: "Access Graph",
+          href: "/features/access-graph/",
+          isExternal: true,
+        },
         { title: "Assist", href: "/features/assist/", isExternal: true },
         {
           title: "Single Sign On",


### PR DESCRIPTION
## Changes
- Added Access graph link under features on the header nav

## Preview
https://docs-git-tuukkatahtinen-navlinks-goteleport.vercel.app/docs/

### Other PR:s
- [Next Repo](https://github.com/gravitational/next/pull/2319)
- [Blog Repo](https://github.com/gravitational/blog/pull/486)