### PR TITLE
Support Vars in HLJS snippets with no spans

### DIFF
--- a/server/fixtures/powershell-var.mdx
+++ b/server/fixtures/powershell-var.mdx
@@ -1,0 +1,3 @@
+```powershell
+certutil -dspublish -f <Var name="user-ca.cer" /> NTAuthCA
+```

--- a/server/fixtures/result/powershell-var.html
+++ b/server/fixtures/result/powershell-var.html
@@ -1,0 +1,2 @@
+<pre><span class="hljs language-powershell">certutil -dspublish -f </span><var name="user-ca.cer"></var><span class="hljs language-powershell"> NTAuthCA
+</span></pre>

--- a/server/rehype-hljs-var.ts
+++ b/server/rehype-hljs-var.ts
@@ -86,7 +86,6 @@ export const rehypeVarInHLJS = (
       const el = node as Element;
       if (
         el.type === "element" &&
-        el.tagName === "span" &&
         el.children.length === 1 &&
         el.children[0].type === "text"
       ) {

--- a/uvu-tests/rehype-hljs-var.test.ts
+++ b/uvu-tests/rehype-hljs-var.test.ts
@@ -33,6 +33,9 @@ const transformer = (options: VFileOptions) =>
       ], // passThrough options says transformer which nodes to leave as is
     }) // Transforms remark to rehype
     .use(rehypeVarInHLJS, {
+      aliases: {
+        bash: ["bsh", "systemd", "code", "powershell"],
+      },
       languages: { hcl: hcl },
     })
     .use(rehypeMdxToHast)
@@ -114,6 +117,21 @@ Suite("Insert Var components as HTML nodes: text after a Var", () => {
     (result.value as string).trim(),
     readFileSync(
       resolve("server/fixtures/result/hcl-vars.html"),
+      "utf-8"
+    ).trim()
+  );
+});
+
+Suite("Insert Var components as HTML nodes: powershell snippet", () => {
+  const result = transformer({
+    value: readFileSync(resolve("server/fixtures/powershell-var.mdx"), "utf-8"),
+    path: "/docs/index.mdx",
+  });
+
+  assert.equal(
+    (result.value as string).trim(),
+    readFileSync(
+      resolve("server/fixtures/result/powershell-var.html"),
       "utf-8"
     ).trim()
   );


### PR DESCRIPTION
Fixes gravitational/teleport#35907

The `rehype-hljs-var` plugin replaces `Var` tags with placeholder strings, applies syntax highlighting, then substitutes the placeholder strings with the original `Var` tags. It assumes that each `Var` must be the child of a `span` tag, though this assumption is not always correct. This change removes the requirement that the plugin check children of `span` tags for `Var`s.