### PR TITLE
Disable banner revalidation

### DIFF
--- a/components/EventBanner/EventBanner.tsx
+++ b/components/EventBanner/EventBanner.tsx
@@ -58,7 +58,7 @@ export const EventBanner: React.FC<{
   initialEvent: EventProps;
 }> = ({ initialEvent }) => {
   const [event, setEvent] = useState<EventProps>(initialEvent);
-  useEffect(() => {
+  /*useEffect(() => {
     const fetchEvent = async () => {
       const tempEvent = await fetch("/api/getfeaturedevent/").then(
         (res) => res.status === 200 && res.json()
@@ -66,7 +66,7 @@ export const EventBanner: React.FC<{
       tempEvent && setEvent(tempEvent.data as EventProps);
     };
     fetchEvent();
-  }, []);
+  }, []);*/
   const { sideButtons } = event;
   return (
     <div className={styles.banner}>

--- a/components/EventBanner/EventBanner.tsx
+++ b/components/EventBanner/EventBanner.tsx
@@ -58,7 +58,9 @@ export const EventBanner: React.FC<{
   initialEvent: EventProps;
 }> = ({ initialEvent }) => {
   const [event, setEvent] = useState<EventProps>(initialEvent);
-  /*useEffect(() => {
+  /* There was an excessive amount of api requests coming in to fetch the event data
+so this fetch is disable until we find and fix the issue or decide to completely drop this version of the revalidation
+useEffect(() => {
     const fetchEvent = async () => {
       const tempEvent = await fetch("/api/getfeaturedevent/").then(
         (res) => res.status === 200 && res.json()


### PR DESCRIPTION
## Changes
- Disabled event banner revalidation while we work on troubleshooting issues with excessive amounts of api requests


Other PRs:
Next https://github.com/gravitational/next/pull/2385
Blog https://github.com/gravitational/blog/pull/501