### PR TITLE
Add scroll margin to the header wrapper

### DIFF
--- a/components/AnchorNavigation/AnchorNavigation.module.css
+++ b/components/AnchorNavigation/AnchorNavigation.module.css
@@ -8,7 +8,7 @@
   width: 240px;
   padding: var(--m-3);
   position: sticky;
-  top: 0;
+  top: 120px;
   max-height: 100vh;
   overflow: auto;
 }

--- a/components/MDX/Headers.module.css
+++ b/components/MDX/Headers.module.css
@@ -2,7 +2,6 @@
   display: none;
   color: var(--color-light-gray);
   text-decoration: none;
-
   &:hover {
     color: var(--color-gray);
   }
@@ -13,6 +12,10 @@
 }
 
 .wrapper {
+  scroll-margin-top:100px;
+  @media (--md-scr) {
+    scroll-margin-top:120px;
+  }
   & code {
     font-size: 0.875em;
   }


### PR DESCRIPTION
## Changes
- Added scroll-margin-top to the header wrapper clsss in components/MDX/headers.module.css
  - 100px on mobile, increased to 120px when window width above 901px
- Adjusted AnchorNavigation top position from 0 to 120px
  
## Preview
https://docs-git-tuukkatahtinen-anchorscrollmargin-goteleport.vercel.app/docs/#set-up-a-demo-cluster