### PR TITLE
Fix 404 docs link

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,10 +7,8 @@ export default function FourOhFour() {
     <>
       <h1>404 - Page Not Found</h1>
       We&apos;re very sorry - we could not find the page you were looking for.
-      Please navigate to the Teleport <Link href="/docs/">
-        Documentation
-      </Link>{" "}
-      or the <a href="/">Home Page</a> to find what you&apos;re looking for.
+      Please navigate to the Teleport <Link href="/">Documentation</Link> or the
+      <a href="/">Home Page</a> to find what you&apos;re looking for.
     </>
   );
 }


### PR DESCRIPTION
The 404 page for docs is using `<Link href="/docs/">` to generate a link to the top of documentation page. This is incorrect: `<Link ...>` is already resolved relative to the top URL for docs, which means in practice this is a link to `/docs/docs`, which doesn't exist. 

Live repro: https://goteleport.com/docs/dummy/. 

This also affects local development, where 404 page on `http://localhost:3000` redirects you to non-existing page `http://localhost:3000/docs/docs`.