### PR TITLE
Add workflow to run the Mintlify migration

### DIFF
--- a/.github/workflows/mintlify.yml
+++ b/.github/workflows/mintlify.yml
@@ -1,0 +1,46 @@
+name: Migrate to Mintlify
+
+on:
+  workflow_call:
+    
+  push:
+    branches:
+      - main
+    paths:
+      - migration/**.mjs
+      - server/**.ts
+
+jobs:
+  run-migration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.MINTLIFY_MIGRATION_APP_ID }}
+          private-key: ${{ secrets.MINTLIFY_MIGRATION_PRIVATE_KEY }}
+
+      - name: Check out mintlify branch
+        uses: actions/checkout@v4
+        with:
+          ref: mintlify
+
+      - name: Run the migration script
+        run: |
+          yarn
+          yarn git-update
+          yarn build-node
+          yarn mintlify
+
+      - name: Push to the remote
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub"
+          git add migration-result
+          # Use the latest version of the Mintlify script, remark plugins, etc.
+          git rebase main
+          git commit -m "[auto] Sync Mintlify source" 
+          git push --set-upstream origin mintlify
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/mintlify.yml
+++ b/.github/workflows/mintlify.yml
@@ -24,23 +24,24 @@ jobs:
       - name: Check out mintlify branch
         uses: actions/checkout@v4
         with:
-          ref: mintlify
+          ref: main
 
-      - name: Run the migration script
+      - name: "Set up git"
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub"
+
+      - name: Run the migration script and push
         run: |
           yarn
           yarn git-update
           yarn build-node
           yarn mintlify
-
-      - name: Push to the remote
-        run: |
-          git config --global user.email "noreply@github.com"
-          git config --global user.name "GitHub"
           git add migration-result
-          # Use the latest version of the Mintlify script, remark plugins, etc.
-          git rebase main
           git commit -m "[auto] Sync Mintlify source" 
-          git push --set-upstream origin mintlify
+          git checkout mintlify
+          git rebase main
+          git push
+
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
The workflow runs the migration script and pushes to the `mintlify`
branch. It assumes that there is a GitHub app with its ID stored in
`vars` and private key in a secret, and that only this GitHub app has
permissions to push to the `mintlify` branch.