### PR TITLE
Remove setHours form getComingEvent

### DIFF
--- a/components/EventBanner/EventBanner.tsx
+++ b/components/EventBanner/EventBanner.tsx
@@ -44,8 +44,8 @@ export interface Event {
 export const getComingEvent = (event?: EventProps) => {
   if (!event || !event?.title)
     return { ...event?.defaultContent, sideButtons: { ...event?.sideButtons } };
-  const currentDate = new Date().setHours(0, 0, 0, 0);
-  const endDate = event.end ? new Date(event.end).setHours(0, 0, 0, 0) : null;
+  const currentDate = new Date();
+  const endDate = event.end ? new Date(event.end) : null;
 
   if (endDate && currentDate > endDate) {
     //Event end date has gone


### PR DESCRIPTION
https://docs-git-tuukkatahtinen-bannerdate-goteleport.vercel.app/docs/

Events were updated to use datetime format on Sanity, which includes the time as well so setting it to 0 to is no longer needed. 

[Related next repo PR](https://github.com/gravitational/next/pull/2405)
[Related Blog PR](https://github.com/gravitational/blog/pull/511)
---
Related Asana task: https://app.asana.com/0/1202613463734613/1206645284163950/f