### PR TITLE
Add Google Ads Conversion tracking

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -54,6 +54,7 @@ export const lato = localLato({
 
 import "styles/varaibles.css";
 import "styles/global.css";
+import { GoogleAdsEvent } from "utils/tracking";
 
 const NEXT_PUBLIC_GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 const NEXT_PUBLIC_GTAG_ID = process.env.NEXT_PUBLIC_GTAG_ID;
@@ -214,12 +215,14 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   useEffect(() => {
     if (!isEngaged) return;
     // Trigger engagement view events here
+    GoogleAdsEvent("30sView");
     sendEngagedView();
   }, [isEngaged]);
 
   const Pageviews = () => {
     // Trigger page views here
-
+    // Google Ads Docs Page Conversion event
+    GoogleAdsEvent("DocsPageView");
     // Qualified page view
     if (!!window["qualified"]) window["qualified"]("page");
     // Posthog page view

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Script from "next/script";
 import type { AppProps } from "next/app";
@@ -67,7 +67,32 @@ interface dataLayerItem {
 declare global {
   var dataLayer: dataLayerItem[]; // eslint-disable-line no-var
 }
+const useIsEngaged = () => {
+  const router = useRouter();
+  const [timerReached, setTimerReached] = useState(false);
+  const [secondPageReached, setSecondPageReached] = useState(false);
+  const [isEngaged, setIsEngaged] = useState(false);
 
+  useEffect(() => {
+    setTimeout(() => {
+      setTimerReached(true);
+    }, 30000);
+    const routeChanged = () => {
+      setSecondPageReached(true);
+    };
+
+    router.events.on("routeChangeComplete", routeChanged);
+    return () => {
+      router.events.off("routeChangeComplete", routeChanged);
+    };
+  }, [router.events]);
+
+  useEffect(() => {
+    setIsEngaged(secondPageReached && timerReached);
+  }, [secondPageReached, timerReached]);
+
+  return isEngaged;
+};
 const Analytics = () => {
   return (
     <>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -223,7 +223,8 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   };
   useEffect(() => {
     posthog(); // init posthog
-
+    // Trigger initial load page views
+    Pageviews();
     router.events.on("routeChangeComplete", Pageviews);
     return () => {
       router.events.off("routeChangeComplete", Pageviews);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -215,6 +215,10 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
 
   const Pageviews = () => {
     // Trigger page views here
+
+    // Qualified page view
+    if (!!window["qualified"]) window["qualified"]("page");
+    // Posthog page view
     sendPageview();
   };
   useEffect(() => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import Script from "next/script";
 import type { AppProps } from "next/app";
 import { DocsContextProvider } from "layouts/DocsPage/context";
-import { posthog, sendPageview } from "utils/posthog";
+import { posthog, sendEngagedView, sendPageview } from "utils/posthog";
 import { TabContextProvider } from "components/Tabs";
 
 // https://larsmagnus.co/blog/how-to-optimize-custom-fonts-with-next-font
@@ -193,14 +193,24 @@ const Analytics = () => {
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
+  const isEngaged = useIsEngaged();
 
+  useEffect(() => {
+    if (!isEngaged) return;
+    // Trigger engagement view events here
+    sendEngagedView();
+  }, [isEngaged]);
+
+  const Pageviews = () => {
+    // Trigger page views here
+    sendPageview();
+  };
   useEffect(() => {
     posthog(); // init posthog
 
-    router.events.on("routeChangeComplete", sendPageview);
-
+    router.events.on("routeChangeComplete", Pageviews);
     return () => {
-      router.events.off("routeChangeComplete", sendPageview);
+      router.events.off("routeChangeComplete", Pageviews);
     };
   }, [router.events]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -187,6 +187,18 @@ const Analytics = () => {
           {/* End Google Tag Manager (noscript) */}
         </>
       )}
+      {/* Quailified Script */}
+      <Script id="script_qualified">
+        {`(function (w, q) {
+          w["QualifiedObject"] = q;
+          w[q] =
+            w[q] ||
+            function () {
+              (w[q].q = w[q].q || []).push(arguments);
+            };
+        })(window, "qualified")`}
+      </Script>
+      <Script src="https://js.qualified.com/qualified.js?token=GWPbwWJLtjykim4W" />
     </>
   );
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -57,6 +57,7 @@ import "styles/global.css";
 
 const NEXT_PUBLIC_GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 const NEXT_PUBLIC_GTAG_ID = process.env.NEXT_PUBLIC_GTAG_ID;
+const NEXT_PUBLIC_GOOGLE_ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
 const MUNCHKIN_ID = process.env.MUNCHKIN_ID;
 
 interface dataLayerItem {
@@ -175,6 +176,9 @@ const Analytics = () => {
                   function gtag(){dataLayer.push(arguments);}
                   gtag('js', new Date());
                   gtag('config', "${NEXT_PUBLIC_GTAG_ID}", {
+                    send_page_view: false
+                  });
+                  gtag('config', "${NEXT_PUBLIC_GOOGLE_ADS_ID}", {
                     send_page_view: false
                   });`}
           </Script>

--- a/utils/posthog.ts
+++ b/utils/posthog.ts
@@ -49,3 +49,11 @@ export const sendDocsFeedback = async (rating: string, comment: string) => {
     "web.docs.comment": comment,
   });
 };
+
+export const sendEngagedView = async () => {
+  const ph = await posthog();
+  ph?.capture("web.engagement.timer", {
+    "web.engagement.sessionTimerThreshold": 30,
+    "web.engagement.sessionPageThreshold": 2,
+  });
+};

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,0 +1,48 @@
+export const isGtagEnabled = () => {
+  return typeof window !== "undefined" && !!window.dataLayer;
+};
+type ConversionLabel = "DocsPageView" | "30sView";
+export const GoogleAdsEvent = (
+  conversion_label: ConversionLabel,
+  payload: Record<string, unknown> = {}
+): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (isGtagEnabled()) {
+      const getLabel = (label: ConversionLabel) => {
+        switch (label) {
+          case "DocsPageView":
+            return "bhkmCKaO5_AYEN2k6cID";
+          case "30sView":
+            return "Dt85CKqO7vAYEN2k6cID";
+        }
+      };
+      // Define that we're sending a Google Ads conversion event
+      // https://developers.google.com/tag-platform/devguides/events#google_ads_conversions
+      // the gtag() function in the docs effectively just calls window.dataLayer.push()
+      window.dataLayer.push({
+        event: "conversion",
+        // send_to: Defines the type of conversion we're sending
+        send_to: `${process.env["NEXT_PUBLIC_GOOGLE_ADS_ID"]}/${getLabel(
+          conversion_label
+        )}`,
+        // Payload: rest of the values for the conversion
+        ...payload,
+        /*eventCallback and eventTimeout are not found in GTM official docs!
+        eventCallback is a function which will execute when all tags which fire on
+        the event have executed; it is scoped to this promise. Always add eventTimeout
+        when you use eventCallback.
+        */
+        eventCallback: () => resolve(),
+
+        /*eventTimeout takes a number in milliseconds as a value after which it calls eventCallback, so
+        even if the tags don't fire or signal completion, eventCallback will be invoked (and
+        this promise resolved)
+        */
+        eventTimeout: 1000,
+      });
+    } else {
+      console.log("Google Ads Tracking Event", payload);
+      resolve();
+    }
+  });
+};


### PR DESCRIPTION
## Changes
- Added GoogleAdsEvent function for sending google ads conversions
- Added docs page view conversion event
- Added 30s page view conversion event

Next PR: https://github.com/gravitational/next/pull/2476
Blog PR: https://github.com/gravitational/blog/pull/537

## Merge checklist
- [ ] Add NEXT_PUBLIC_GOOGLE_ADS_ID environment variable to Vercel "AW-XXXXXX"
- [ ] Disable Google Ads event triggers on GTM
  - [ ] Google Ads - Conversion - Contact Sales
  - [ ] Google Ads - Conversion - Resource Download
  - [ ] Google Ads - Conversion - Subscribe
  - [ ] Google Ads - Conversion - Teleport Team Signup
  - [ ] Google Ads- 30s Page View
  - [ ] Google Ads - Page View Counter
- [ ] Merge the PRs

## Testing Checklist
- [ ] Docs Pageview events fire on page load
- [ ] 30s Pageview fires after spending 30s on the site and navigating to at least one other page via internal link