### PR TITLE
added javascript to handle version links

### DIFF
--- a/layouts/DocsPage/DocsPage.tsx
+++ b/layouts/DocsPage/DocsPage.tsx
@@ -67,6 +67,11 @@ const DocsPage = ({
 
   let path = getPath(latest);
 
+  let urlCurrent = "/docs" + path;
+  // handles the case where it's the home page with / to avoid /docs/docs/
+  if (path == "/")
+    urlCurrent = "/";
+
   return (
     <>
       <Head
@@ -105,14 +110,14 @@ const DocsPage = ({
                   {isOldVersion && (
                     <>
                       This chapter covers a past release: {current}. We
-                      recommend the <Link href={`/docs${path}`}>latest</Link>{" "}
+                      recommend the <Link href={`${urlCurrent}`}>latest</Link>{" "}
                       version instead.
                     </>
                   )}
                   {isBetaVersion && (
                     <>
                       This chapter covers an upcoming release: {current}. We
-                      recommend the <Link href={`/docs${path}`}>latest</Link>{" "}
+                      recommend the <Link href={`${urlCurrent}`}>latest</Link>{" "}
                       version instead.
                     </>
                   )}

--- a/layouts/DocsPage/DocsPage.tsx
+++ b/layouts/DocsPage/DocsPage.tsx
@@ -69,8 +69,7 @@ const DocsPage = ({
 
   let urlCurrent = "/docs" + path;
   // handles the case where it's the home page with / to avoid /docs/docs/
-  if (path == "/")
-    urlCurrent = "/";
+  if (path == "/") urlCurrent = "/";
 
   return (
     <>


### PR DESCRIPTION
Currently a user can get the link `/docs/docs` for the latest version link on the home page.