### PR TITLE
fix include linter

### DIFF
--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -425,7 +425,6 @@ export default function remarkIncludes({
       vfile,
       startIndex: lastErrorIndex,
       ruleId: "includes",
-      source: "remark-lint",
     });
   };
 }

--- a/server/remark-variables.ts
+++ b/server/remark-variables.ts
@@ -142,7 +142,6 @@ export default function remarkVariables({
       vfile,
       startIndex: lastErrorIndex,
       ruleId: "variables",
-      source: "remark-lint",
     });
   };
 }

--- a/server/update-vfile-messages.ts
+++ b/server/update-vfile-messages.ts
@@ -8,14 +8,12 @@ interface UpdateMessagesOptions {
   vfile: VFile;
   startIndex: number;
   ruleId: string;
-  source: string;
 }
 
 export default function updateMessages({
   vfile,
   startIndex,
   ruleId,
-  source,
 }: UpdateMessagesOptions) {
   let index = startIndex;
 
@@ -23,7 +21,6 @@ export default function updateMessages({
     const message = vfile.messages[index];
 
     message.ruleId = ruleId;
-    message.source = source;
     message.fatal = true;
 
     index++;


### PR DESCRIPTION
I made a docs PR that moved an include file, but I missed one place where the docs still used the old include file path.
That was this PR:
- https://github.com/gravitational/teleport/pull/43137

The linter should have caught that mistake, but it didn't.
Here's the lint docs CI run for that PR: https://github.com/gravitational/teleport/actions/runs/9570290956/job/26384715831

For some reason, setting "source" on the vfile messages makes it not report an error consistently.
I have no idea why.
Depending on the surrounding context, it sometimes caught the error or sometimes did not.
For example, this is not caught (the token.mdx file doesn't exist):
```md
(!docs/pages/includes/database-access/token.mdx!)
```

but if I add some text before/after, it is caught:
```md
blah blah

(!docs/pages/includes/database-access/token.mdx!)

blah blah
```

With this fix, it catches the bad include consistently:
```
content/16.x/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx
  139:1-139:50  error  Wrong import path docs/pages/includes/database-access/token.mdx in file content/16.x/docs/pages/database-access/enroll-aws-databases/redshift-serverless.mdx.  includes
```

It also caught other bad includes I was not aware of:

```
content/14.x/docs/pages/contributing/documentation/reference.mdx
    450:1-454:4  error    Wrong import path docs/pages/includes/include.mdx in file content/14.x/docs/pages/contributing/documentation/reference.mdx.     
```

```
content/15.x/docs/pages/contributing/documentation/reference.mdx
    462:1-466:4  error    Wrong import path docs/pages/includes/include.mdx in file content/15.x/docs/pages/contributing/documentation/reference.mdx.                                    includes
```