### PR TITLE
Allow underscores in docs for the Terraform reference

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -48,6 +48,7 @@ const configLint = {
     ["lint-ordered-list-marker-value", "single"],
     ["lint-maximum-heading-length", false],
     ["lint-no-shortcut-reference-link", false],
+    ["lint-no-file-name-irregular-characters", false],
     [
       remarkIncludes, // Lints (!include.ext!) syntax
       {


### PR DESCRIPTION
This PR allows underscores in doc files.

This is needed for the Terraform reference as the official Terraform generator uses underscores in generated files.

See slack thread: https://gravitational.slack.com/archives/CM7E1200L/p1719520421630299?thread_ts=1719519569.240369&cid=CM7E1200L