### PR TITLE
Generate docs sidebar sections automatically

### DIFF
--- a/layouts/DocsPage/types.ts
+++ b/layouts/DocsPage/types.ts
@@ -43,6 +43,7 @@ export interface NavigationCategory {
   icon: IconName;
   title: string;
   entries: NavigationItem[];
+  generateFrom?: string;
 }
 
 interface LinkWithRedirect {

--- a/server/fixtures/result/code-snippet-heredoc.mdx
+++ b/server/fixtures/result/code-snippet-heredoc.mdx
@@ -67,6 +67,8 @@
 
   </CodeLine>
 
+  <br />
+
   <CommandComment data-type="descr">
     Create role
   </CommandComment>

--- a/server/pages-helpers.ts
+++ b/server/pages-helpers.ts
@@ -4,9 +4,9 @@
 
 import type { MDXPage, MDXPageData, MDXPageFrontmatter } from "./types-unist";
 
-import { resolve } from "path";
 import { readSync } from "to-vfile";
 import matter from "gray-matter";
+import { sep, parse, dirname, resolve, join } from "path";
 
 export const extensions = ["md", "mdx", "ts", "tsx", "js", "jsx"];
 
@@ -59,5 +59,80 @@ export const getPageInfo = <T = MDXPageFrontmatter>(
     cache[path] = result as MDXPage<MDXPageFrontmatter>;
   }
 
+  return result;
+};
+
+const getEntryForPath = (fs, filePath) => {
+  const txt = fs.readFileSync(filePath, "utf8");
+  const { data } = matter(txt);
+  const slug = filePath.split("docs/pages")[1].replace(".mdx", "/");
+  return {
+    title: data.title,
+    slug: slug,
+  };
+};
+
+export const generateNavPaths = (fs, dirPath) => {
+  const firstLvl = fs.readdirSync(dirPath, "utf8");
+  let result = [];
+  let firstLvlFiles = new Set();
+  let firstLvlDirs = new Set();
+  firstLvl.forEach((p) => {
+    const fullPath = join(dirPath, p);
+    const info = fs.statSync(fullPath);
+    if (info.isDirectory()) {
+      firstLvlDirs.add(fullPath);
+      return;
+    }
+    firstLvlFiles.add(fullPath);
+  });
+  let sectionIntros = new Set();
+  firstLvlDirs.forEach((d: string) => {
+    const { name } = parse(d);
+    const asFile = join(d, name + ".mdx");
+
+    if (!fs.existsSync(asFile)) {
+      throw `subdirectory in generated sidebar section ${d} has no category page ${asFile}`;
+    }
+    sectionIntros.add(asFile);
+    return;
+  });
+
+  // Add files with no corresponding directory to the navigation first. Section
+  // introductions, by convention, have a filename that corresponds to the
+  // subdirectory containing pages in the section, or have the name
+  // "introduction.mdx".
+  firstLvlFiles.forEach((f) => {
+    result.push(getEntryForPath(fs, f));
+  });
+
+  sectionIntros.forEach((si: string) => {
+    const { slug, title } = getEntryForPath(fs, si);
+    const section = {
+      title: title,
+      slug: slug,
+      entries: [],
+    };
+    const sectionDir = dirname(si);
+    const secondLvl = fs.readdirSync(sectionDir, "utf8");
+    secondLvl.forEach((f2) => {
+      const { name } = parse(f2);
+
+      // The directory name is the same as the filename, meaning that we have
+      // already used this as a category page.
+      if (sectionDir.endsWith(name)) {
+        return;
+      }
+
+      const fullPath2 = join(sectionDir, f2);
+      const stat = fs.statSync(fullPath2);
+      if (stat.isDirectory()) {
+        return;
+      }
+
+      section.entries.push(getEntryForPath(fs, fullPath2));
+    });
+    result.push(section);
+  });
   return result;
 };

--- a/uvu-tests/remark-code-snippet.test.ts
+++ b/uvu-tests/remark-code-snippet.test.ts
@@ -243,7 +243,7 @@ Suite("Variables in multiline command support", () => {
   assert.equal(result, expected);
 });
 
-Suite.only("Includes empty lines in example command output", () => {
+Suite("Includes empty lines in example command output", () => {
   const value = readFileSync(
     resolve("server/fixtures/code-snippet-empty-line.mdx"),
     "utf-8"

--- a/uvu-tests/remark-includes.test.ts
+++ b/uvu-tests/remark-includes.test.ts
@@ -590,21 +590,19 @@ boundary" section.
   }
 );
 
-Suite.only(
-  "Interprets anchor-only links correctly when loading partials",
-  () => {
-    const actual = transformer({
-      value: `Here is the outer page.
+Suite("Interprets anchor-only links correctly when loading partials", () => {
+  const actual = transformer({
+    value: `Here is the outer page.
 
 (!anchor-links.mdx!)
 
 `,
-      path: "server/fixtures/mypage.mdx",
-    }).toString();
+    path: "server/fixtures/mypage.mdx",
+  }).toString();
 
-    assert.equal(
-      actual,
-      `Here is the outer page.
+  assert.equal(
+    actual,
+    `Here is the outer page.
 
 This is a [link to an anchor](#this-is-a-section).
 
@@ -612,8 +610,7 @@ This is a [link to an anchor](#this-is-a-section).
 
 This is content within the section.
 `
-    );
-  }
-);
+  );
+});
 
 Suite.run();


### PR DESCRIPTION
Add a `config.json` field within each `navigation` entry called `generateFrom`. This designates a relative path from `docs/pages` from which to generate entries within the sidebar.

When generating pages, a function called `generateNavPaths` looks for pages to use as second-level section introductions. These can either be called `introduction.mdx` or have the same name as a second-level subdirectory.

Adding a `generateFrom` field is consistent with the Docusaurus approach to sidebar generation, in which a configuration field indicates which directory to generate a section from. This gives us control over the title and icons we use for navigation sections, which aren't available to fetch from a directory tree alone. It also lets us use the current, hardcoded `entries` approach for some sections if we need to.

Also un-skips some accidentally skipped tests.