### PR TITLE
Allow four levels of sidebar entries

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,10 @@
 import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
-  stories: ["../components/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: [
+    "../components/**/*.stories.@(js|jsx|ts|tsx)",
+    "../layouts/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
   addons: ["@storybook/addon-interactions", "@storybook/addon-viewport"],
   framework: {
     name: "@storybook/nextjs",

--- a/layouts/DocsPage/Navigation.module.css
+++ b/layouts/DocsPage/Navigation.module.css
@@ -107,10 +107,21 @@
     display: block;
   }
 
-  & .link {
-    padding-left: var(--m-4);
+  & .link{
     font-size: var(--fs-text-sm);
     line-height: var(--lh-md);
+  }
+
+  & .link-1 {
+    padding-left: var(--m-4);
+  }
+
+  & .link-2 {
+    padding-left: var(--m-5);
+  }
+
+  & .link-3 {
+    padding-left: var(--m-6);
   }
 
   .link.active + & {

--- a/layouts/DocsPage/Navigation.stories.tsx
+++ b/layouts/DocsPage/Navigation.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+import { default as DocNavigation } from "layouts/DocsPage/Navigation";
+import { NavigationCategory } from "./types";
+
+export const NavigationFourLevels = () => {
+  const data = [
+    {
+      icon: "cloud",
+      title: "Enroll Resources",
+      entries: [
+        {
+          title: "Machine ID",
+          slug: "/enroll-resources/machine-id/",
+          entries: [
+            {
+              title: "Deploy Machine ID",
+              slug: "/enroll-resources/machine-id/deployment/",
+              entries: [
+                {
+                  title: "Deploy Machine ID on AWS",
+                  slug: "/enroll-resources/machine-id/deployment/aws/",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  return (
+    <DocNavigation
+      data={data as Array<NavigationCategory>}
+      section={true}
+      currentVersion="16.x"
+      currentPathGetter={() => {
+        return "/enroll-resources/machine-id/deployment/aws/";
+      }}
+    ></DocNavigation>
+  );
+};
+
+const meta: Meta<typeof DocNavigation> = {
+  title: "layouts/DocNavigation",
+  component: NavigationFourLevels,
+};
+export default meta;

--- a/server/remark-toc.ts
+++ b/server/remark-toc.ts
@@ -25,7 +25,7 @@ const relativePathToFile = (root: string, filepath: string) => {
 // properties:
 // - result: a string containing the resulting list of links.
 // - error: an error message encountered during processing
-export const getTOC = (filePath: string, fs = nodeFS) => {
+export const getTOC = (filePath: string, fs: any = nodeFS) => {
   const dirPath = path.dirname(filePath);
   if (!fs.existsSync(dirPath)) {
     return {

--- a/uvu-tests/config-docs.test.ts
+++ b/uvu-tests/config-docs.test.ts
@@ -289,54 +289,57 @@ title: MySQL Guide
   }
 );
 
-Suite(
-  "generateNavPaths shows third-level category pages on the sidebar",
-  () => {
-    const files = {
-      "/docs/pages/database-access/guides/guides.mdx": `---
+Suite("generateNavPaths shows third-level pages on the sidebar", () => {
+  const files = {
+    "/docs/pages/database-access/guides/guides.mdx": `---
 title: Database Access Guides
 ---`,
-      "/docs/pages/database-access/guides/postgres.mdx": `---
+    "/docs/pages/database-access/guides/postgres.mdx": `---
 title: Postgres Guide
 ---`,
-      "/docs/pages/database-access/guides/mysql.mdx": `---
+    "/docs/pages/database-access/guides/mysql.mdx": `---
 title: MySQL Guide
 ---`,
-      "/docs/pages/database-access/guides/rbac/rbac.mdx": `---
+    "/docs/pages/database-access/guides/rbac/rbac.mdx": `---
 title: Database Access RBAC
 ---`,
-      "/docs/pages/database-access/guides/rbac/get-started.mdx": `---
+    "/docs/pages/database-access/guides/rbac/get-started.mdx": `---
 title: Get Started with DB RBAC
 ---`,
-    };
+  };
 
-    const expected = [
-      {
-        title: "Database Access Guides",
-        slug: "/database-access/guides/guides/",
-        entries: [
-          {
-            title: "Database Access RBAC",
-            slug: "/database-access/guides/rbac/rbac/",
-          },
-          {
-            title: "MySQL Guide",
-            slug: "/database-access/guides/mysql/",
-          },
-          {
-            title: "Postgres Guide",
-            slug: "/database-access/guides/postgres/",
-          },
-        ],
-      },
-    ];
+  const expected = [
+    {
+      title: "Database Access Guides",
+      slug: "/database-access/guides/guides/",
+      entries: [
+        {
+          title: "Database Access RBAC",
+          slug: "/database-access/guides/rbac/rbac/",
+          entries: [
+            {
+              title: "Get Started with DB RBAC",
+              slug: "/database-access/guides/rbac/get-started/",
+            },
+          ],
+        },
+        {
+          title: "MySQL Guide",
+          slug: "/database-access/guides/mysql/",
+        },
+        {
+          title: "Postgres Guide",
+          slug: "/database-access/guides/postgres/",
+        },
+      ],
+    },
+  ];
 
-    const vol = Volume.fromJSON(files);
-    const fs = createFsFromVolume(vol);
-    const actual = generateNavPaths(fs, "/docs/pages/database-access");
-    assert.equal(actual, expected);
-  }
-);
+  const vol = Volume.fromJSON(files);
+  const fs = createFsFromVolume(vol);
+  const actual = generateNavPaths(fs, "/docs/pages/database-access");
+  assert.equal(actual, expected);
+});
 
 Suite(
   "allows category pages in the same directory as the associated subdirectory",
@@ -367,6 +370,12 @@ title: Get Started with DB RBAC
           {
             title: "Database Access RBAC",
             slug: "/database-access/guides/rbac/",
+            entries: [
+              {
+                title: "Get Started with DB RBAC",
+                slug: "/database-access/guides/rbac/get-started/",
+              },
+            ],
           },
           {
             title: "MySQL Guide",
@@ -386,5 +395,43 @@ title: Get Started with DB RBAC
     assert.equal(actual, expected);
   }
 );
+
+Suite("generates four levels of the sidebar", () => {
+  const files = {
+    "/docs/pages/database-access/guides/guides.mdx": `---
+title: Database Access Guides
+---`,
+    "/docs/pages/database-access/guides/deployment/kubernetes.mdx": `---
+title: Database Access Kubernetes Deployment
+---`,
+    "/docs/pages/database-access/guides/deployment/deployment.mdx": `---
+title: Database Access Deployment Guides
+---`,
+  };
+
+  const expected = [
+    {
+      title: "Database Access Guides",
+      slug: "/database-access/guides/guides/",
+      entries: [
+        {
+          title: "Database Access Deployment Guides",
+          slug: "/database-access/guides/deployment/deployment/",
+          entries: [
+            {
+              title: "Database Access Kubernetes Deployment",
+              slug: "/database-access/guides/deployment/kubernetes/",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const vol = Volume.fromJSON(files);
+  const fs = createFsFromVolume(vol);
+  let actual = generateNavPaths(fs, "/docs/pages/database-access");
+  assert.equal(actual, expected);
+});
 
 Suite.run();


### PR DESCRIPTION
Currently, the code that generates the navigation sidebar from a
directory tree stops at the second level of a given top-level section.
However, some sections include three levels of content. This change
edits the sidebar generator so it works recursively.

Also fix an issue with the `DocsNavigationItems` component that prevents
the docs site from highlighting sidebar entries past two levels of
depth. The component treats a sidebar subsection as "active" if one of
its entries is equivalent to the current page path.

But if the current page path is a grandchild of a sidebar subsection,
this means that the component hides the grandchild, since none of the
children of the subsection is equivalent to the current page. This
change determines that a sidebar subsection is "active" if the selected
path _starts with_ the subsection path.

Also edit the CSS padding of navigation links to depend on the current
level of the navigation menu. This allows for indentation of submenu
links beyond the second level.