### PR TITLE
Navigation menu keyboard events

### DIFF
--- a/components/DropdownMenu/DropdownSubMenu.tsx
+++ b/components/DropdownMenu/DropdownSubMenu.tsx
@@ -36,6 +36,14 @@ const DropdownSubMenu = ({ items }: DropdownMenuProps) => {
                   index === activeTab ? styles.active : ""
                 )}
                 onClick={() => setActiveTab(index)}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setActiveTab(index);
+                  }
+                }}
+                aria-expanded={activeTab === index}
               >
                 {submenuTitle}
                 <Icon name="arrowRight" size="sm" />

--- a/components/Menu/Category.tsx
+++ b/components/Menu/Category.tsx
@@ -70,6 +70,7 @@ const MenuCategory = ({
         ? submenus
         : columns
       : null;
+
   const toggleOpened = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (children) {
@@ -81,11 +82,23 @@ const MenuCategory = ({
     },
     [opened, children, id, onToggleOpened, onClick]
   );
+
   const open = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       onHover(id);
     },
     [id, onHover]
+  );
+
+  const keyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        !opened ? onToggleOpened(id) : onToggleOpened(null);
+      }
+      if (e.key === "Escape") onToggleOpened(null);
+    },
+    [id, opened, onToggleOpened]
   );
 
   const containsSubCategories = !!columns || !!submenus;
@@ -116,7 +129,10 @@ const MenuCategory = ({
             className={cn(styles.menuButton, opened ? styles.opened : "")}
             onClick={toggleOpened}
             onMouseEnter={open}
+            tabIndex={0}
             data-testid={testId}
+            onKeyDown={keyDown}
+            aria-expanded={opened}
           >
             {title}
             {isDropdown === "dropdown" && (

--- a/components/Menu/Category.tsx
+++ b/components/Menu/Category.tsx
@@ -112,6 +112,11 @@ const MenuCategory = ({
         )}
         ref={ref}
         onMouseLeave={() => toggleOpened(null)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onToggleOpened(null);
+          }
+        }}
       >
         {isDropdown === "link" ? (
           <Link


### PR DESCRIPTION
Preview: https://docs-git-pietikinnunen-nav-accessibility-goteleport.vercel.app/docs/

Enables very basic keyboard navigation for the header nav menu and aria-expanded values to improve the accessibility of the site. 
- Enable using `tab` or `shift`+`tab` to go through the header navigation items. 
- Pressing `space` or `enter/return` key when a main navigation menu item or a submenu is in focus should open it.
- Pressing `escape` when any navigation item is in focus should close the navigation

Associated PRs in the other repos:
https://github.com/gravitational/next/pull/2542
https://github.com/gravitational/blog/pull/564