### PR TITLE
Catch Docusaurus build issues

### DIFF
--- a/server/fixtures/includes-vars-erroneous-include.mdx
+++ b/server/fixtures/includes-vars-erroneous-include.mdx
@@ -1,0 +1,5 @@
+## Installation
+
+Here is a test for including variables in an MDX file.
+
+(!install-version.mdx version="10" unsupport="9" !)

--- a/server/remark-includes.ts
+++ b/server/remark-includes.ts
@@ -244,6 +244,21 @@ const resolveIncludes = ({
         content = content.replace(varRegexp, finalVal);
       }
 
+      // Catch unresolved parameters, which can break docs builds
+      const paramRE = new RegExp(`{{ ?\\w+ ?}}`, "g");
+      const unresolvedParams = Array.from(content.matchAll(paramRE));
+      if (unresolvedParams.length > 0) {
+        const errs = unresolvedParams
+          .map((el) => {
+            return el[0];
+          })
+          .join(",");
+
+        error =
+          `${includePath}: the following partial parameters were not assigned and have no default value: ` +
+          errs;
+      }
+
       return content;
     } else {
       error = `Wrong import path ${includePath} in file ${filePath}.`;

--- a/uvu-tests/remark-includes.test.ts
+++ b/uvu-tests/remark-includes.test.ts
@@ -483,6 +483,27 @@ Suite("Resolves template variables in includes", () => {
   assert.equal(result, expected);
 });
 
+Suite("Throws an error if a variable is unresolved and has no default", () => {
+  const value = readFileSync(
+    resolve("server/fixtures/includes-vars-erroneous-include.mdx"),
+    "utf-8"
+  );
+
+  const out = transformer(
+    {
+      value,
+      path: "/content/4.0/docs/pages/filename.mdx",
+    },
+    { lint: true }
+  );
+
+  assert.equal(out.messages.length, 1);
+  assert.equal(
+    out.messages[0].reason,
+    "The following partial parameters were not assigned and have no default value: {{ unsupported }}"
+  );
+});
+
 Suite(
   "Resolves relative links in partials based on the path of the partial",
   () => {


### PR DESCRIPTION
Break the docs build on states that are acceptable for the current
NextJS-based docs engine but cause Docusaurus builds to fail:

- **Unresolved partial parameters:** Edit the `remark-includes` linter
  to ensure that all parameters declared within a partial (using `{{
  param }}` syntax) are either (a) assigned by the user or (b) given a
  default value. Otherwise, when we move to the new docs engine, builds
  will fail on unresolved parameters.

- **Add more config checks:** Throw an exception for duplicate redirects
  and redirects where the `source` points to an existing file. With the
  current logic, this check takes place with every page build. While
  this is not ideal, and leads to noisy error output, we should be
  migrating soon and will not need to deal with this for long.