### PR TITLE
Fix path checking logic

### DIFF
--- a/server/config-docs.ts
+++ b/server/config-docs.ts
@@ -253,17 +253,13 @@ const correspondingFileExistsForURL = (
   // Each URL in the docs config begins at docs/pages within a given version's
   // content directory. Get the MDX file for a given URL and check if it
   // exists in the filesystem. URL paths must point to (a) an MDX file with
-  // the same name as the final path segment; (b) a file named "index.mdx"; or
-  // (c) a file named "introduction.mdx".
+  // the same name as the final path segment; or (b) a file named "index.mdx".
   const mdxPath = urlpath.replace(/\/$/, ".mdx");
   const docsPagePath = resolve(join(dirRoot, mdxPath));
-
   const indexPath = resolve(join(dirRoot, urlpath + "index.mdx"));
 
-  const introPath = resolve(join(dirRoot, urlpath + "introduction.mdx"));
-
   if (
-    [docsPagePath, indexPath, introPath].find((p) => {
+    [docsPagePath, indexPath].find((p) => {
       return fs.existsSync(p);
     }) == undefined
   ) {

--- a/uvu-tests/config-docs.test.ts
+++ b/uvu-tests/config-docs.test.ts
@@ -34,11 +34,6 @@ Suite("Ensures that URLs correspond to docs pages", () => {
         title: "About",
         entries: [
           {
-            title: "Introduction",
-            slug: "/about/",
-            forScopes: ["oss"],
-          },
-          {
             title: "Projects",
             slug: "/about/projects/",
             forScopes: ["oss"],


### PR DESCRIPTION
`categoryPagePathForDir` considers a page called `introduction.mdx` the same as the root of the containing directory. This is incorrect, and this equivalence actually depends on whether a redirect exists between the `introduction` page and the directory root.